### PR TITLE
카테고리 기능 구현 및 레이아웃 ui변경

### DIFF
--- a/fe/src/components/common/dropdown/Backdrop.tsx
+++ b/fe/src/components/common/dropdown/Backdrop.tsx
@@ -12,6 +12,6 @@ const backdropStyle = (theme: Theme) => css`
   position: fixed;
   top: 0;
   width: 393px;
-  height: 852px;
+  height: 100vh;
   background-color: ${theme.color.neutral.overlay};
 `;

--- a/fe/src/components/common/modal/Dim.tsx
+++ b/fe/src/components/common/modal/Dim.tsx
@@ -21,5 +21,3 @@ const dimStyle = (theme: Theme) => {
     background-color: ${theme.color.neutral.overlay};
   `;
 };
-// position: absolute;
-// height: 852px;

--- a/fe/src/components/common/modal/Dim.tsx
+++ b/fe/src/components/common/modal/Dim.tsx
@@ -17,7 +17,9 @@ const dimStyle = (theme: Theme) => {
     inset: 0;
     z-index: 105;
     width: 393px;
-    height: 852px;
+    height: 100vh;
     background-color: ${theme.color.neutral.overlay};
   `;
 };
+// position: absolute;
+// height: 852px;

--- a/fe/src/components/common/navBar/NavBar.tsx
+++ b/fe/src/components/common/navBar/NavBar.tsx
@@ -1,5 +1,12 @@
 import { PATH } from '@/constants/path';
-import { Heart, Home, MessageNoti, Message, News, UserCircle } from '@components/common/icons';
+import {
+  Heart,
+  Home,
+  MessageNoti,
+  Message,
+  News,
+  UserCircle,
+} from '@components/common/icons';
 import { Theme, css } from '@emotion/react';
 import { NavLink } from 'react-router-dom';
 
@@ -52,7 +59,7 @@ export const NavBar: React.FC = () => {
 
 const navStyle = (theme: Theme) => {
   return css`
-    position: sticky;
+    position: fixed;
     bottom: 0;
 
     box-sizing: border-box;
@@ -95,3 +102,4 @@ const navStyle = (theme: Theme) => {
     }
   `;
 };
+// position: sticky;

--- a/fe/src/components/home/Category.tsx
+++ b/fe/src/components/home/Category.tsx
@@ -4,77 +4,74 @@ import { Title } from '../common/topBar/Title';
 import { LeftButton } from '../common/topBar/LeftButton';
 import { Button } from '../common/button/Button';
 import { ChevronLeft } from '../common/icons';
-import { useAnimation } from '@/hooks/animation';
 import { Option } from './Option';
 
 type Props = {
   categories?: CategoryType[];
-  showCategory: boolean;
+  onSelectCategory: (id: number) => void;
   onCloseCategory: () => void;
 };
 
 export const Category: React.FC<Props> = ({
   categories,
-  showCategory,
+  onSelectCategory,
   onCloseCategory,
 }) => {
-  // TODO 메인에서 미리 데이터가 받아와져 있어야함
-  const { shouldRender, handleTransitionEnd, animationTrigger } =
-    useAnimation(showCategory);
-
   return (
     <>
-      {shouldRender && (
-        <div
-          css={(theme) => pageStyle(theme, animationTrigger)}
-          onTransitionEnd={handleTransitionEnd}
-        >
-          <TopBar>
-            <LeftButton>
-              <Button variant="text" onClick={onCloseCategory}>
-                <ChevronLeft className="button__back" />
-                닫기
-              </Button>
-            </LeftButton>
-            <Title>카테고리</Title>
-          </TopBar>
-          <div className="page">
-            {categories &&
-              categories.map((category) => (
-                <Option
-                  key={category.id}
-                  icon={category.imageUrl}
-                  label={category.name}
-                  onSelectCategory={() => {}}
-                />
-              ))}
-          </div>
+      <div css={(theme) => pageStyle(theme)}>
+        <TopBar>
+          <LeftButton>
+            <Button variant="text" onClick={onCloseCategory}>
+              <ChevronLeft className="button__back" />
+              닫기
+            </Button>
+          </LeftButton>
+          <Title>카테고리</Title>
+        </TopBar>
+        <div className="page">
+          {categories &&
+            categories.map((category) => (
+              <Option
+                key={category.id}
+                icon={category.imageUrl}
+                label={category.name}
+                onSelectCategory={() => {
+                  onSelectCategory(category.id);
+                  onCloseCategory();
+                }}
+              />
+            ))}
         </div>
-      )}
+      </div>
     </>
   );
 };
 
-const pageStyle = (theme: Theme, animationTrigger: boolean) => {
+const pageStyle = (theme: Theme) => {
   return css`
+    overflow-y: auto;
+    scroll-behavior: smooth;
+    ::-webkit-scrollbar {
+      display: none;
+    }
     width: 100%;
-    border: 1px solid red;
+    height: 100vh;
+
     position: absolute;
-    left: 0;
     top: 0;
+    left: 100%;
+    z-index: 100;
+
     background-color: ${theme.color.neutral.background};
-    transition: 300ms ease;
 
     .button__back {
       stroke: ${theme.color.neutral.textStrong};
     }
 
-    ${animationTrigger ? '' : 'left:100%;  opacity: 0;'};
-
     .page {
       padding: 40px;
       box-sizing: border-box;
-      border: 1px solid green;
 
       display: flex;
       flex-wrap: wrap;

--- a/fe/src/layout/Layout.tsx
+++ b/fe/src/layout/Layout.tsx
@@ -26,4 +26,4 @@ const layoutStyle = (animationTrigger: boolean) => {
     transform: translateX(${animationTrigger ? '-392px' : '0px'});
   `;
 };
-//min-height: 100vh;
+

--- a/fe/src/layout/Layout.tsx
+++ b/fe/src/layout/Layout.tsx
@@ -5,8 +5,9 @@ import { useAnimation } from '@/hooks/animation';
 import { useLayoutStore } from '@/store/layoutStore';
 
 export const Layout: React.FC = () => {
-  const { shouldMove } = useLayoutStore();
-  const { handleTransitionEnd, animationTrigger } = useAnimation(shouldMove);
+  const { shouldSlideLeft } = useLayoutStore();
+  const { handleTransitionEnd, animationTrigger } =
+    useAnimation(shouldSlideLeft);
 
   return (
     <div
@@ -26,4 +27,3 @@ const layoutStyle = (animationTrigger: boolean) => {
     transform: translateX(${animationTrigger ? '-392px' : '0px'});
   `;
 };
-

--- a/fe/src/layout/Layout.tsx
+++ b/fe/src/layout/Layout.tsx
@@ -1,11 +1,29 @@
+import { css } from '@emotion/react';
 import { NavBar } from '@/components/common/navBar/NavBar';
 import { Outlet } from 'react-router-dom';
+import { useAnimation } from '@/hooks/animation';
+import { useLayoutStore } from '@/store/layoutStore';
 
 export const Layout: React.FC = () => {
+  const { shouldMove } = useLayoutStore();
+  const { handleTransitionEnd, animationTrigger } = useAnimation(shouldMove);
+
   return (
-    <>
+    <div
+      css={() => layoutStyle(animationTrigger)}
+      onTransitionEnd={handleTransitionEnd}
+    >
       <Outlet />
       <NavBar />
-    </>
+    </div>
   );
 };
+
+const layoutStyle = (animationTrigger: boolean) => {
+  return css`
+    min-height: 100vh;
+    transition: 300ms ease;
+    transform: translateX(${animationTrigger ? '-392px' : '0px'});
+  `;
+};
+//min-height: 100vh;

--- a/fe/src/pages/Home.tsx
+++ b/fe/src/pages/Home.tsx
@@ -84,6 +84,15 @@ export const Home: React.FC = () => {
       <div css={pageStyle}>
         <>
           <TopBar>
+            <RightButton>
+              <Button
+                variant="text"
+                className="button__topbar"
+                onClick={onOpenCategory}
+              >
+                <LayoutGrid />
+              </Button>
+            </RightButton>
             <LeftButton>
               <Dropdown autoClose>
                 <Button variant="text" className="button__topbar">
@@ -107,15 +116,6 @@ export const Home: React.FC = () => {
                 </MenuBox>
               </Dropdown>
             </LeftButton>
-            <RightButton>
-              <Button
-                variant="text"
-                className="button__topbar"
-                onClick={onOpenCategory}
-              >
-                <LayoutGrid />
-              </Button>
-            </RightButton>
           </TopBar>
           <Button variant="fab" size="l" className="button__add">
             <Plus />
@@ -154,6 +154,7 @@ const pageStyle = (theme: Theme) => {
     .button__topbar {
       stroke: ${theme.color.neutral.textStrong};
     }
+
     .button__add {
       position: absolute;
       bottom: 88px;

--- a/fe/src/pages/Home.tsx
+++ b/fe/src/pages/Home.tsx
@@ -20,6 +20,7 @@ import { useMyLocations } from '@/hooks/location';
 import { usePopupStore } from '@/store/popupStore';
 import { Category } from '@/components/home/Category';
 import { useCategories } from '@/hooks/category';
+import { useLayoutStore } from '@/store/layoutStore';
 
 // TODO 페이지가 로드됐을때, 내동네 api 호출
 // TODO 모달에서 동네를 추가하거나 삭제하면, 영향을 받아 locations가 수정돼야함
@@ -28,7 +29,11 @@ export const Home: React.FC = () => {
   const { categories } = useCategories();
   const { togglePopup, setCurrentDim } = usePopupStore();
   const [selected, setSelected] = useState<number | null>(null);
-  const [showCategory, setShowCategory] = useState(false);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
+    null,
+  );
+
+  const { setshouldMove } = useLayoutStore();
   // TODO 필터링과 대표동네 설정은 별개로 처리함에 따라, 초기에는 모든 동네의 물품을 보여줌(초안)
   // TODO useQueries이용해서 로딩, 에러처리 한꺼번에?
 
@@ -56,12 +61,12 @@ export const Home: React.FC = () => {
 
   const onOpenCategory = () => {
     //TODO : 카테고리 페이지 보여주기
-    setShowCategory(true);
+    setshouldMove();
   };
 
   const onCloseCategory = () => {
     //TODO : 카테고리 페이지 닫기
-    setShowCategory(false);
+    setshouldMove();
   };
 
   const onFilterProducts = (id: number) => {
@@ -69,66 +74,69 @@ export const Home: React.FC = () => {
     setSelected(id);
   };
 
+  const onSelectCategory = (id: number) => {
+    //TODO 카테고리 선택
+    setSelectedCategoryId(id);
+  };
+
   return (
     <>
       <div css={pageStyle}>
-        {!showCategory && (
-          <>
-            <TopBar>
-              <LeftButton>
-                <Dropdown autoClose>
-                  <Button variant="text" className="button__topbar">
-                    역삼1동
-                    <ChevronDown />
-                  </Button>
-                  <MenuBox>
-                    {locations &&
-                      locations.map((location) => (
-                        <MenuItem
-                          key={location.id}
-                          state={
-                            selected === location.id ? 'selected' : 'default'
-                          }
-                          onClick={() => onFilterProducts(location.id)}
-                        >
-                          {location.name}
-                        </MenuItem>
-                      ))}
-                    <MenuItem onClick={onOpenModal}>내 동네 설정하기</MenuItem>
-                  </MenuBox>
-                </Dropdown>
-              </LeftButton>
-              <RightButton>
-                <Button
-                  variant="text"
-                  className="button__topbar"
-                  onClick={onOpenCategory}
-                >
-                  <LayoutGrid />
+        <>
+          <TopBar>
+            <LeftButton>
+              <Dropdown autoClose>
+                <Button variant="text" className="button__topbar">
+                  역삼1동
+                  <ChevronDown />
                 </Button>
-              </RightButton>
-            </TopBar>
-            <Button variant="fab" size="l" className="button__add">
-              <Plus />
-            </Button>
-            <ListBox>
-              {mock.products.map((product) => (
-                <ListItem
-                  key={product.id}
-                  product={product}
-                  onOpenDetail={() => onOpenDetail(product.id)}
-                />
-              ))}
-            </ListBox>
-            <LocationModal />
-          </>
-        )}
+                <MenuBox>
+                  {locations &&
+                    locations.map((location) => (
+                      <MenuItem
+                        key={location.id}
+                        state={
+                          selected === location.id ? 'selected' : 'default'
+                        }
+                        onClick={() => onFilterProducts(location.id)}
+                      >
+                        {location.name}
+                      </MenuItem>
+                    ))}
+                  <MenuItem onClick={onOpenModal}>내 동네 설정하기</MenuItem>
+                </MenuBox>
+              </Dropdown>
+            </LeftButton>
+            <RightButton>
+              <Button
+                variant="text"
+                className="button__topbar"
+                onClick={onOpenCategory}
+              >
+                <LayoutGrid />
+              </Button>
+            </RightButton>
+          </TopBar>
+          <Button variant="fab" size="l" className="button__add">
+            <Plus />
+          </Button>
+          <ListBox>
+            {mock.products.map((product) => (
+              <ListItem
+                key={product.id}
+                product={product}
+                onOpenDetail={() => onOpenDetail(product.id)}
+              />
+            ))}
+          </ListBox>
+          <LocationModal />
+        </>
       </div>
 
       <Category
         categories={categories}
-        showCategory={showCategory}
         onCloseCategory={onCloseCategory}
+        onSelectCategory={onSelectCategory}
       />
     </>
   );
@@ -136,7 +144,12 @@ export const Home: React.FC = () => {
 
 const pageStyle = (theme: Theme) => {
   return css`
-    flex: 1;
+    overflow-y: auto;
+    scroll-behavior: smooth;
+    ::-webkit-scrollbar {
+      display: none;
+    }
+    height: 100vh;
 
     .button__topbar {
       stroke: ${theme.color.neutral.textStrong};

--- a/fe/src/pages/Home.tsx
+++ b/fe/src/pages/Home.tsx
@@ -33,7 +33,7 @@ export const Home: React.FC = () => {
     null,
   );
 
-  const { setshouldMove } = useLayoutStore();
+  const { setShouldSlideLeft } = useLayoutStore();
   // TODO 필터링과 대표동네 설정은 별개로 처리함에 따라, 초기에는 모든 동네의 물품을 보여줌(초안)
   // TODO useQueries이용해서 로딩, 에러처리 한꺼번에?
 
@@ -61,12 +61,12 @@ export const Home: React.FC = () => {
 
   const onOpenCategory = () => {
     //TODO : 카테고리 페이지 보여주기
-    setshouldMove();
+    setShouldSlideLeft();
   };
 
   const onCloseCategory = () => {
     //TODO : 카테고리 페이지 닫기
-    setshouldMove();
+    setShouldSlideLeft();
   };
 
   const onFilterProducts = (id: number) => {

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -50,4 +50,3 @@ const globalStyle = css`
     display: none;
   }
 `;
-// height: 852px;

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -40,10 +40,9 @@ export const AppRoutes: React.FC = () => {
 
 const globalStyle = css`
   width: 393px;
-  height: 852px;
+  height: 100vh;
   margin: auto;
-  border: 1px solid black;
-
+  box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.1);
   overflow-x: hidden;
   overflow-y: auto;
 
@@ -51,3 +50,4 @@ const globalStyle = css`
     display: none;
   }
 `;
+// height: 852px;

--- a/fe/src/store/layoutStore.ts
+++ b/fe/src/store/layoutStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+type LayoutState = {
+  shouldMove: boolean;
+  setshouldMove: () => void;
+};
+
+export const useLayoutStore = create<LayoutState>((set, get) => ({
+  shouldMove: false,
+  setshouldMove: () => {
+    const currentShouldMove = get().shouldMove;
+    set({ shouldMove: !currentShouldMove });
+  },
+}));

--- a/fe/src/store/layoutStore.ts
+++ b/fe/src/store/layoutStore.ts
@@ -1,14 +1,14 @@
 import { create } from 'zustand';
 
 type LayoutState = {
-  shouldMove: boolean;
-  setshouldMove: () => void;
+  shouldSlideLeft: boolean;
+  setShouldSlideLeft: () => void;
 };
 
 export const useLayoutStore = create<LayoutState>((set, get) => ({
-  shouldMove: false,
-  setshouldMove: () => {
-    const currentShouldMove = get().shouldMove;
-    set({ shouldMove: !currentShouldMove });
+  shouldSlideLeft: false,
+  setShouldSlideLeft: () => {
+    const currentState = get().shouldSlideLeft;
+    set({ shouldSlideLeft: !currentState });
   },
 }));

--- a/fe/src/styles/globalStyle.ts
+++ b/fe/src/styles/globalStyle.ts
@@ -3,7 +3,6 @@ import { css, Theme } from '@emotion/react';
 export const globalStyle = (theme: Theme) => css`
   #root {
     position: relative;
-    overflow: hidden;
   }
 
   body {


### PR DESCRIPTION
## What is this PR? 👓
카테고리 기능 구현 및 레이아웃 ui변경

## Key changes 🔑
- 레이아웃 ui변경
  - 세로를 꽉채우는 형태
  - [**BUG**] 드롭다운을 열었을 때 스크롤이 안되도록 고정해 주었던 dropdown내부 로직이 영향력을 잃었습니다
  
  레이아웃을 변경하고, home.tsx에도 100vh로 높이를 주어야 내부 목록에 대한 스크롤이 가능해져서 
  세팅을 하고 보니 `document.getElementById('app-layout') `여기서 app-layout 이 아니라 home을 찾아주어야 고정이 됩니다 ㅠ
  - 이런식으로 DOM을 하나하나 찾아주는것은 무리이니 zustand를 이용해서 현재 scroll여부를 제어해줄 수는 없을까? `overflow-y: ${shouldScroll ? 'auto' : 'hidden'}` 생각해보았는데, 
  전역이다보니 드롭다운이 2개 이상일때의 관리를 어떻게 해주어야 할지 아직 답을 못찾았습니다 
- 페이지 슬라이딩 작동 방식을 하위 페이지 제어가 아닌 레이아웃 컨테이너 자체를 이동시켜주는 것으로 변경

## To reviewers 👋
- 백드롭이 깔려있을때 카테고리 버튼(rightbutton)이 눌리던 문제 - 해결O / 원인파악은 X
  - 백드롭의 렌더 위치는 header => leftButton(rightbutton과 형제 위치에 렌더) => dropdown =>  backdrop 으로 rightbutton보다 안쪽에 존재함
  - rightbutton이 백드롭보다 더 상위요소로 렌더링 되는 것을 원인으로 생각했으나 header외의 다른 상위요소인 fab버튼은 rightbutton버튼과 달리 안눌리는 것을 확인
  - 순서상 읽기에 조금 이상하지만 jsx작성시 rightbutton을 leftbutton보다 먼저 렌더링 시켜주니 해결
- 이것 역시 css 쌓임 맥락에 의한 것인지..? 잘 모르겠습니다 
```
<TopBar>
  <RightButton>
    <Button
      variant="text"
      className="button__topbar"
      onClick={onOpenCategory}
    >
      <LayoutGrid />
    </Button>
  </RightButton>
  <LeftButton>
    <Dropdown autoClose>
      <Button variant="text" className="button__topbar">
        역삼1동
        <ChevronDown />
      </Button>
      <MenuBox>
        {locations &&
          locations.map((location) => (
            <MenuItem
              key={location.id}
              state={
                selected === location.id ? 'selected' : 'default'
              }
              onClick={() => onFilterProducts(location.id)}
            >
              {location.name}
            </MenuItem>
          ))}
        <MenuItem onClick={onOpenModal}>내 동네 설정하기</MenuItem>
      </MenuBox>
    </Dropdown>
  </LeftButton>
</TopBar>
```
###  header => leftButton(rightbutton과 형제 위치에 렌더) => dropdown =>  backdrop
![image](https://github.com/masters2023-4th-project-carrot-talk/carrot-talk-fe/assets/86706366/799a4d4f-e0c8-4db3-9bb1-aba7e60c9a82)

