### PR TITLE
피드백 반영 리팩토링

### DIFF
--- a/fe/src/api/api.ts
+++ b/fe/src/api/api.ts
@@ -58,11 +58,7 @@ export const checkNickname = async (nickname: string) => {
   });
 };
 
-export const signup = async (signupInfo: {
-  nickname: string;
-  mainLocationId: number;
-  subLocationId?: number;
-}) => {
+export const signup = async (signupInfo: SignupData) => {
   return fetchData('/api/users/signup', {
     method: 'POST',
     headers: {

--- a/fe/src/components/common/dropdown/Dropdown.tsx
+++ b/fe/src/components/common/dropdown/Dropdown.tsx
@@ -1,7 +1,6 @@
 import { ButtonProps } from '@components/common/button/Button';
-import { DropdownContext } from '@/contexts/DropdownContext';
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { cloneElement, useState } from 'react';
 import { MenuBoxProps } from '../menu/MenuBox';
 import { Backdrop } from './Backdrop';
 
@@ -9,20 +8,14 @@ type Props = {
   opener: React.ReactElement<ButtonProps>;
   menu: React.ReactElement<MenuBoxProps>;
   align?: 'left' | 'right';
-  autoClose?: boolean;
 };
 
 export const Dropdown: React.FC<Props> = ({
   opener,
   menu,
   align,
-  autoClose = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-
-  if (!opener || !menu) {
-    return null;
-  }
 
   const openMenu = () => {
     const appLayout = document.getElementById('app-layout') as HTMLElement;
@@ -37,17 +30,15 @@ export const Dropdown: React.FC<Props> = ({
   };
 
   return (
-    <DropdownContext.Provider value={{ autoClose, closeMenu }}>
-      <div css={() => dropdownStyle(align)}>
-        <div onClick={openMenu}>{opener}</div>
-        {isOpen && (
-          <>
-            <Backdrop onClick={closeMenu} />
-            {menu}
-          </>
-        )}
-      </div>
-    </DropdownContext.Provider>
+    <div css={() => dropdownStyle(align)}>
+      <div onClick={openMenu}>{opener}</div>
+      {isOpen && (
+        <>
+          <Backdrop onClick={closeMenu} />
+          {cloneElement(menu, { onClick: closeMenu })}
+        </>
+      )}
+    </div>
   );
 };
 

--- a/fe/src/components/common/menu/MenuBox.tsx
+++ b/fe/src/components/common/menu/MenuBox.tsx
@@ -2,10 +2,11 @@ import { Theme, css } from '@emotion/react';
 
 export type MenuBoxProps = {
   children?: React.ReactNode;
+  onClick?: () => void;
 };
 
-export const MenuBox: React.FC<MenuBoxProps> = ({ children }) => {
-  return <ul css={(theme) => menuItemStyle(theme)}>{children}</ul>;
+export const MenuBox: React.FC<MenuBoxProps> = ({ children, onClick }) => {
+  return <ul css={(theme) => menuItemStyle(theme)} onClick={onClick}>{children}</ul>;
 };
 
 const menuItemStyle = (theme: Theme) => css`

--- a/fe/src/components/common/menu/MenuItem.tsx
+++ b/fe/src/components/common/menu/MenuItem.tsx
@@ -1,6 +1,4 @@
-import { DropdownContext } from '@/contexts/DropdownContext';
 import { Theme, css } from '@emotion/react';
-import { useContext } from 'react';
 
 type Props = {
   state?: 'default' | 'selected';
@@ -15,11 +13,8 @@ export const MenuItem: React.FC<Props> = ({
   variant,
   onClick,
 }) => {
-  const { autoClose, closeMenu } = useContext(DropdownContext);
-
   const onMenuItemClick = () => {
     onClick?.();
-    autoClose && closeMenu();
   };
 
   return (

--- a/fe/src/components/common/navBar/NavBar.tsx
+++ b/fe/src/components/common/navBar/NavBar.tsx
@@ -38,7 +38,7 @@ export const NavBar: React.FC = () => {
     },
     {
       label: '내 계정',
-      path: PATH.auth,
+      path: PATH.account,
       icon: <UserCircle />,
     },
   ];

--- a/fe/src/constants/path.ts
+++ b/fe/src/constants/path.ts
@@ -3,7 +3,7 @@ export const PATH = {
   sales: '/sales',
   interests: '/interests',
   chat: '/chat',
-  auth: '/auth',
+  account: '/account',
   redirect: '/oauth/redirect',
   signup: '/auth/signup',
   notFound: '/*',

--- a/fe/src/constants/path.ts
+++ b/fe/src/constants/path.ts
@@ -5,7 +5,7 @@ export const PATH = {
   chat: '/chat',
   account: '/account',
   redirect: '/oauth/redirect',
-  signup: '/auth/signup',
+  signup: '/signup',
   notFound: '/*',
 };
 

--- a/fe/src/hooks/useNickname.ts
+++ b/fe/src/hooks/useNickname.ts
@@ -1,4 +1,4 @@
-import { useNicknameCheckQuery } from '@/queries/auth';
+import { useNicknameCheck } from '@/queries/auth';
 import { useEffect, useState } from 'react';
 
 type NicknameInputType = {
@@ -17,7 +17,7 @@ export const useNickname = ({
       validateNickname,
       defaultWarning,
     });
-  const nicknameCheckResult = useNicknameCheckQuery(nickname);
+  const nicknameCheckResult = useNicknameCheck(nickname);
 
   useEffect(() => {
     setIsValidNicknameCheck(false);

--- a/fe/src/hooks/useNickname.ts
+++ b/fe/src/hooks/useNickname.ts
@@ -1,0 +1,72 @@
+import { checkNickname } from '@/api/api';
+import { useEffect, useState } from 'react';
+import { useQuery } from 'react-query';
+
+type NicknameInputType = {
+  defaultWarning: string;
+  initialNickname?: string;
+  validateNickname?: (nickname: string) => boolean;
+};
+
+export const useNickname = ({
+  defaultWarning,
+  validateNickname = () => true,
+}: NicknameInputType) => {
+  const [isValidNicknameCheck, setIsValidNicknameCheck] = useState(false);
+  const { nickname, onChangeNickname, isValidNickname, nicknameInputWarning } =
+    useNicknameInput({
+      validateNickname,
+      defaultWarning,
+    });
+  const nicknameCheckResult = useNicknameCheckQuery(nickname);
+
+  useEffect(() => {
+    setIsValidNicknameCheck(false);
+  }, [nickname]);
+
+  const checkNicknameUnique = () => {
+    nicknameCheckResult.refetch();
+    setIsValidNicknameCheck(true);
+  };
+
+  return {
+    nickname,
+    isValidNickname,
+    isUniqueNickname: isValidNicknameCheck && nicknameCheckResult.data?.isUnique,
+    nicknameInputWarning: (isValidNickname && nicknameCheckResult.data?.message) || nicknameInputWarning,
+    onChangeNickname,
+    checkNicknameUnique,
+  };
+};
+
+const useNicknameInput = ({
+  defaultWarning,
+  validateNickname = () => true,
+}: NicknameInputType) => {
+  const [nickname, setNickname] = useState('');
+
+  const onChangeNickname = (value: string) => {
+    setNickname(value);
+  };
+
+  const isValidNickname = validateNickname(nickname);
+  const nicknameInputWarning = isValidNickname ? '' : defaultWarning;
+
+  return {
+    nickname,
+    onChangeNickname,
+    isValidNickname,
+    nicknameInputWarning,
+  };
+};
+
+const useNicknameCheckQuery = (nickname: string) =>
+  useQuery({
+    queryKey: ['uniqueNickname'],
+    queryFn: () => checkNickname(nickname),
+    select: (data) => ({
+      isUnique: data.success,
+      message: data?.errorCode?.message ?? '',
+    }),
+    enabled: false,
+  });

--- a/fe/src/hooks/useNickname.ts
+++ b/fe/src/hooks/useNickname.ts
@@ -1,6 +1,5 @@
-import { checkNickname } from '@/api/api';
+import { useNicknameCheckQuery } from '@/queries/auth';
 import { useEffect, useState } from 'react';
-import { useQuery } from 'react-query';
 
 type NicknameInputType = {
   defaultWarning: string;
@@ -32,8 +31,11 @@ export const useNickname = ({
   return {
     nickname,
     isValidNickname,
-    isUniqueNickname: isValidNicknameCheck && nicknameCheckResult.data?.isUnique,
-    nicknameInputWarning: (isValidNickname && nicknameCheckResult.data?.message) || nicknameInputWarning,
+    isUniqueNickname:
+      isValidNicknameCheck && nicknameCheckResult.data?.isUnique,
+    nicknameInputWarning:
+      (isValidNickname && nicknameCheckResult.data?.message) ||
+      nicknameInputWarning,
     onChangeNickname,
     checkNicknameUnique,
   };
@@ -59,14 +61,3 @@ const useNicknameInput = ({
     nicknameInputWarning,
   };
 };
-
-const useNicknameCheckQuery = (nickname: string) =>
-  useQuery({
-    queryKey: ['uniqueNickname'],
-    queryFn: () => checkNickname(nickname),
-    select: (data) => ({
-      isUnique: data.success,
-      message: data?.errorCode?.message ?? '',
-    }),
-    enabled: false,
-  });

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
-import { token, users } from './data/users';
 import { categoryList } from './data/categories';
 import { locationsWithQuery } from './data/locations';
+import { token, users } from './data/users';
 
 let locations: LocationType[] = [
   { id: 1, name: '안양99동', isMainLocation: true },
@@ -177,6 +177,9 @@ export const handlers = [
       return res(ctx.status(200), ctx.json({ success: false }));
     }
 
-    return res(ctx.status(200), ctx.json({ success: true, accessToken: token }));
-  })
+    return res(
+      ctx.status(200),
+      ctx.json({ success: true, data: { accessToken: token } }),
+    );
+  }),
 ];

--- a/fe/src/pages/Account.tsx
+++ b/fe/src/pages/Account.tsx
@@ -1,21 +1,21 @@
+import { useLogoutMutation } from '@/queries/auth';
+import kakaoLogin from '@assets/kakao_login.png';
 import { ReactComponent as UserCircle } from '@assets/user-circle.svg';
 import { Button } from '@components/common/button/Button';
 import { Beez } from '@components/common/icons';
 import { Title } from '@components/common/topBar/Title';
 import { TopBar } from '@components/common/topBar/TopBar';
 import { KAKAO_AUTH_URL, PATH } from '@constants/path';
-import { useLogout } from '@/queries/auth';
+import { Theme, css } from '@emotion/react';
 import { useAuth } from '@hooks/useAuth';
 import { clearLoginInfo } from '@utils/localStorage';
-import kakaoLogin from '@assets/kakao_login.png';
-import { Theme, css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
 export const Account: React.FC = () => {
   const navigate = useNavigate();
 
   const { isLogin, userInfo } = useAuth();
-  const { mutate: logoutMutation } = useLogout(() => {
+  const logoutMutation = useLogoutMutation(() => {
     clearLoginInfo();
     navigate(PATH.account, { replace: true });
   });
@@ -25,7 +25,7 @@ export const Account: React.FC = () => {
   };
 
   const onClickLogout = () => {
-    logoutMutation();
+    logoutMutation.mutate();
   };
 
   return (

--- a/fe/src/pages/Account.tsx
+++ b/fe/src/pages/Account.tsx
@@ -15,17 +15,19 @@ export const Account: React.FC = () => {
   const navigate = useNavigate();
 
   const { isLogin, userInfo } = useAuth();
-  const logoutMutation = useLogoutMutation(() => {
-    clearLoginInfo();
-    navigate(PATH.account, { replace: true });
-  });
+  const logoutMutation = useLogoutMutation();
 
   const onClickLogin = () => {
     location.assign(KAKAO_AUTH_URL);
   };
 
   const onClickLogout = () => {
-    logoutMutation.mutate();
+    logoutMutation.mutate(undefined, {
+      onSuccess: () => {
+        clearLoginInfo();
+        navigate(PATH.account, { replace: true });
+      },
+    });
   };
 
   return (

--- a/fe/src/pages/Account.tsx
+++ b/fe/src/pages/Account.tsx
@@ -11,13 +11,13 @@ import kakaoLogin from '@assets/kakao_login.png';
 import { Theme, css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
-export const Auth: React.FC = () => {
+export const Account: React.FC = () => {
   const navigate = useNavigate();
 
   const { isLogin, userInfo } = useAuth();
   const { mutate: logoutMutation } = useLogout(() => {
     clearLoginInfo();
-    navigate(PATH.auth, { replace: true });
+    navigate(PATH.account, { replace: true });
   });
 
   const onClickLogin = () => {

--- a/fe/src/pages/Account.tsx
+++ b/fe/src/pages/Account.tsx
@@ -1,4 +1,4 @@
-import { useLogoutMutation } from '@/queries/auth';
+import { useLogout } from '@/queries/auth';
 import kakaoLogin from '@assets/kakao_login.png';
 import { ReactComponent as UserCircle } from '@assets/user-circle.svg';
 import { Button } from '@components/common/button/Button';
@@ -15,7 +15,7 @@ export const Account: React.FC = () => {
   const navigate = useNavigate();
 
   const { isLogin, userInfo } = useAuth();
-  const logoutMutation = useLogoutMutation();
+  const logoutMutation = useLogout();
 
   const onClickLogin = () => {
     location.assign(KAKAO_AUTH_URL);

--- a/fe/src/pages/Home.tsx
+++ b/fe/src/pages/Home.tsx
@@ -149,7 +149,6 @@ export const Home: React.FC = () => {
                     )}
                   </MenuBox>
                 }
-                autoClose
               />
             </LeftButton>
             <RightButton>

--- a/fe/src/pages/OauthLoading.tsx
+++ b/fe/src/pages/OauthLoading.tsx
@@ -1,4 +1,4 @@
-import { useLoginMutation } from '@/queries/auth';
+import { useLogin } from '@/queries/auth';
 import { useAuthStore } from '@/stores/authStore';
 import kakao from '@assets/kakao.png';
 import { PATH } from '@constants/path';
@@ -10,7 +10,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 export const OauthLoading: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { mutate: loginMutate } = useLoginMutation();
+  const { mutate: loginMutate } = useLogin();
   const { setSignUpInProgress } = useAuthStore();
 
   const onLoginSucceeded = useCallback(

--- a/fe/src/pages/OauthLoading.tsx
+++ b/fe/src/pages/OauthLoading.tsx
@@ -1,28 +1,16 @@
-import { PATH } from '@constants/path';
-import { useLogin } from '@/queries/auth';
-import { setAccessToken, setLoginInfo } from '@utils/localStorage';
+import { useLoginMutation } from '@/queries/auth';
 import kakao from '@assets/kakao.png';
+import { PATH } from '@constants/path';
 import { Theme, css } from '@emotion/react';
+import { setAccessToken, setLoginInfo } from '@utils/localStorage';
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-
-type LoginResponseType =
-  | {
-      isUser: false;
-      accessToken: string;
-    }
-  | {
-      isUser: true;
-      accessToken: string;
-      refreshToken: string;
-      user: UserType;
-    };
 
 export const OauthLoading: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
-  const onLogin = (data: LoginResponseType) => {
+  const onLogin = (data: LoginDataFromServer['data']) => {
     if (data.isUser) {
       setLoginInfo(data);
       navigate(PATH.home, { replace: true });
@@ -36,15 +24,11 @@ export const OauthLoading: React.FC = () => {
     navigate(PATH.account, { replace: true });
   };
 
-  const { mutate: loginMutation } = useLogin(
-    searchParams.get('code') || '',
-    onLogin,
-    onLoginFail,
-  );
+  const loginMutation = useLoginMutation(onLogin, onLoginFail);
 
   useEffect(() => {
-    loginMutation();
-  }, [loginMutation]);
+    loginMutation.mutate(searchParams.get('code') || '');
+  }, [loginMutation, searchParams]);
 
   return (
     <>

--- a/fe/src/pages/OauthLoading.tsx
+++ b/fe/src/pages/OauthLoading.tsx
@@ -9,9 +9,9 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 export const OauthLoading: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const loginMutation = useLoginMutation();
+  const { mutate: loginMutate } = useLoginMutation();
 
-  const onLogin = useCallback(
+  const onLoginSucceeded = useCallback(
     (data: LoginDataFromServer['data']) => {
       if (data.isUser) {
         setLoginInfo(data);
@@ -24,21 +24,21 @@ export const OauthLoading: React.FC = () => {
     [navigate],
   );
 
-  const onLoginFail = useCallback(() => {
+  const onLoginFailed = useCallback(() => {
     navigate(PATH.account, { replace: true });
   }, [navigate]);
 
   useEffect(() => {
-    loginMutation.mutate(searchParams.get('code') || '', {
+    loginMutate(searchParams.get('code') || '', {
       onSuccess: (res) => {
         if (res.success) {
-          onLogin(res.data);
+          onLoginSucceeded(res.data);
         } else {
-          onLoginFail();
+          onLoginFailed();
         }
       },
     });
-  }, [loginMutation, searchParams, onLogin, onLoginFail]);
+  }, [loginMutate, searchParams, onLoginSucceeded, onLoginFailed]);
 
   return (
     <>

--- a/fe/src/pages/OauthLoading.tsx
+++ b/fe/src/pages/OauthLoading.tsx
@@ -1,4 +1,5 @@
 import { useLoginMutation } from '@/queries/auth';
+import { useAuthStore } from '@/stores/authStore';
 import kakao from '@assets/kakao.png';
 import { PATH } from '@constants/path';
 import { Theme, css } from '@emotion/react';
@@ -10,6 +11,7 @@ export const OauthLoading: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { mutate: loginMutate } = useLoginMutation();
+  const { setSignUpInProgress } = useAuthStore();
 
   const onLoginSucceeded = useCallback(
     (data: LoginDataFromServer['data']) => {
@@ -18,10 +20,11 @@ export const OauthLoading: React.FC = () => {
         navigate(PATH.home, { replace: true });
       } else {
         setAccessToken(data.accessToken);
-        navigate(PATH.signup, { replace: true, state: { isOauth: true } });
+        setSignUpInProgress(true);
+        navigate(PATH.signup, { replace: true });
       }
     },
-    [navigate],
+    [navigate, setSignUpInProgress],
   );
 
   const onLoginFailed = useCallback(() => {

--- a/fe/src/pages/OauthLoading.tsx
+++ b/fe/src/pages/OauthLoading.tsx
@@ -33,7 +33,7 @@ export const OauthLoading: React.FC = () => {
   };
 
   const onLoginFail = () => {
-    navigate(PATH.auth, { replace: true });
+    navigate(PATH.account, { replace: true });
   };
 
   const { mutate: loginMutation } = useLogin(

--- a/fe/src/pages/Signup.tsx
+++ b/fe/src/pages/Signup.tsx
@@ -1,5 +1,6 @@
 import { useNickname } from '@/hooks/useNickname';
 import { useSignupMutation } from '@/queries/auth';
+import { useAuthStore } from '@/stores/authStore';
 import { usePopupStore } from '@/stores/popupStore';
 import { setLoginInfo } from '@/utils/localStorage';
 import { ReactComponent as Check } from '@assets/check.svg';
@@ -14,15 +15,10 @@ import { TopBar } from '@components/common/topBar/TopBar';
 import { PATH } from '@constants/path';
 import { Theme, css } from '@emotion/react';
 import { useLocationControl } from '@hooks/useLocationControl';
-import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 
 export const Signup: React.FC = () => {
   const navigate = useNavigate();
-  const routeLocation = useLocation();
-
-  const { locations } = useLocationControl();
-  const { togglePopup, setCurrentDim } = usePopupStore();
-  const signupMutation = useSignupMutation();
 
   const {
     nickname,
@@ -36,10 +32,10 @@ export const Signup: React.FC = () => {
       /^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]{2,10}$/.test(nickname),
     defaultWarning: '2~10글자 닉네임을 입력하세요',
   });
-
-  if (!routeLocation.state?.isOauth) {
-    return <Navigate to={PATH.account} replace={true} />;
-  }
+  const { locations } = useLocationControl();
+  const { togglePopup, setCurrentDim } = usePopupStore();
+  const { signUpInProgress } = useAuthStore();
+  const signupMutation = useSignupMutation();
 
   const submitEnabled = isUniqueNickname && locations && locations.length > 0;
 
@@ -82,6 +78,10 @@ export const Signup: React.FC = () => {
       },
     });
   };
+
+  if (!signUpInProgress) {
+    return <Navigate to={PATH.account} replace={true} />;
+  }
 
   return (
     <>

--- a/fe/src/pages/Signup.tsx
+++ b/fe/src/pages/Signup.tsx
@@ -1,5 +1,5 @@
 import { useNickname } from '@/hooks/useNickname';
-import { useSignup } from '@/queries/auth';
+import { useSignupMutation } from '@/queries/auth';
 import { usePopupStore } from '@/stores/popupStore';
 import { ReactComponent as Check } from '@assets/check.svg';
 import { ReactComponent as Plus } from '@assets/plus.svg';
@@ -21,7 +21,7 @@ export const Signup: React.FC = () => {
 
   const { locations } = useLocationControl();
   const { togglePopup, setCurrentDim } = usePopupStore();
-  const { mutate: signupWithInfo } = useSignup();
+  const signupMutation = useSignupMutation();
 
   const {
     nickname,
@@ -69,7 +69,7 @@ export const Signup: React.FC = () => {
       ...(!!subLocationId && { subLocationId }),
     };
 
-    signupWithInfo(signupInfo);
+    signupMutation.mutate(signupInfo);
 
     navigate(PATH.home, { replace: true });
   };

--- a/fe/src/pages/Signup.tsx
+++ b/fe/src/pages/Signup.tsx
@@ -1,5 +1,5 @@
 import { useNickname } from '@/hooks/useNickname';
-import { useSignupMutation } from '@/queries/auth';
+import { useSignup } from '@/queries/auth';
 import { useAuthStore } from '@/stores/authStore';
 import { usePopupStore } from '@/stores/popupStore';
 import { setLoginInfo } from '@/utils/localStorage';
@@ -35,7 +35,7 @@ export const Signup: React.FC = () => {
   const { locations } = useLocationControl();
   const { togglePopup, setCurrentDim } = usePopupStore();
   const { signUpInProgress } = useAuthStore();
-  const signupMutation = useSignupMutation();
+  const signupMutation = useSignup();
 
   const submitEnabled = isUniqueNickname && locations && locations.length > 0;
 

--- a/fe/src/pages/Signup.tsx
+++ b/fe/src/pages/Signup.tsx
@@ -49,7 +49,7 @@ export const Signup: React.FC = () => {
   }, [nickname]);
 
   if (!routeLocation.state?.isOauth) {
-    return <Navigate to={PATH.auth} replace={true} />;
+    return <Navigate to={PATH.account} replace={true} />;
   }
 
   const invalidNickName = !/^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]{2,10}$/.test(nickname);
@@ -60,7 +60,7 @@ export const Signup: React.FC = () => {
     invalidNickName || !nicknameCheckPassed || locations?.length === 0;
 
   const goToAuth = () => {
-    navigate(PATH.auth, { replace: true });
+    navigate(PATH.account, { replace: true });
   };
 
   const changeNickname = (value: string) => {

--- a/fe/src/pages/Signup.tsx
+++ b/fe/src/pages/Signup.tsx
@@ -1,6 +1,7 @@
 import { useNickname } from '@/hooks/useNickname';
 import { useSignupMutation } from '@/queries/auth';
 import { usePopupStore } from '@/stores/popupStore';
+import { setLoginInfo } from '@/utils/localStorage';
 import { ReactComponent as Check } from '@assets/check.svg';
 import { ReactComponent as Plus } from '@assets/plus.svg';
 import { Button } from '@components/common/button/Button';
@@ -69,9 +70,17 @@ export const Signup: React.FC = () => {
       ...(!!subLocationId && { subLocationId }),
     };
 
-    signupMutation.mutate(signupInfo);
-
-    navigate(PATH.home, { replace: true });
+    signupMutation.mutate(signupInfo, {
+      onSuccess: ({ data }) => {
+        setLoginInfo(data);
+        navigate(PATH.home, { replace: true });
+      },
+      onError: (error) => {
+        if (error instanceof Error) {
+          throw error;
+        }
+      },
+    });
   };
 
   return (

--- a/fe/src/queries/auth.ts
+++ b/fe/src/queries/auth.ts
@@ -1,10 +1,6 @@
 import { checkNickname, login, logout, refreshToken, signup } from '@api/api';
 import { QUERY_KEY } from '@constants/queryKey';
-import {
-  getRefreshToken,
-  setAccessToken,
-  setLoginInfo,
-} from '@utils/localStorage';
+import { getRefreshToken, setAccessToken } from '@utils/localStorage';
 import { useMutation, useQuery } from 'react-query';
 
 export const useNicknameCheckQuery = (nickname: string) =>
@@ -17,39 +13,6 @@ export const useNicknameCheckQuery = (nickname: string) =>
     }),
     enabled: false,
     retry: false,
-  });
-
-export const useSignupMutation = () =>
-  useMutation<SignupDataFromServer, unknown, SignupData>({
-    mutationFn: (signupInfo: SignupData) => signup(signupInfo),
-    onSuccess: ({ data }) => {
-      setLoginInfo(data);
-    },
-    onError: (error) => {
-      if (error instanceof Error) {
-        throw error;
-      }
-    },
-  });
-
-export const useLoginMutation = (
-  onLogin: (data: LoginDataFromServer['data']) => void,
-  onLoginFail: () => void,
-) =>
-  useMutation<LoginDataFromServer, unknown, string>({
-    mutationFn: (code: string) => login(code),
-    onSuccess: ({ success, data }) => {
-      if (!success) {
-        onLoginFail();
-      }
-      onLogin(data);
-    },
-  });
-
-export const useLogoutMutation = (onLogout: () => void) =>
-  useMutation({
-    mutationFn: () => logout(),
-    onSuccess: () => onLogout(),
   });
 
 export const useTokenRefreshQuery = () => {
@@ -70,3 +33,18 @@ export const useTokenRefreshQuery = () => {
     setAccessToken(tokenRefreshQuery.data);
   }
 };
+
+export const useSignupMutation = () =>
+  useMutation<SignupDataFromServer, unknown, SignupData>({
+    mutationFn: (signupInfo: SignupData) => signup(signupInfo),
+  });
+
+export const useLoginMutation = () =>
+  useMutation<LoginDataFromServer, unknown, string>({
+    mutationFn: (code: string) => login(code),
+  });
+
+export const useLogoutMutation = () =>
+  useMutation({
+    mutationFn: () => logout(),
+  });

--- a/fe/src/queries/auth.ts
+++ b/fe/src/queries/auth.ts
@@ -11,6 +11,10 @@ export const useNicknameCheckQuery = (nickname: string) =>
   useQuery({
     queryKey: [QUERY_KEY.nicknameCheck, nickname],
     queryFn: () => checkNickname(nickname),
+    select: (data) => ({
+      isUnique: data.success,
+      message: data?.errorCode?.message ?? '',
+    }),
     enabled: false,
     retry: false,
   });

--- a/fe/src/queries/auth.ts
+++ b/fe/src/queries/auth.ts
@@ -1,61 +1,39 @@
 import { checkNickname, login, logout, refreshToken, signup } from '@api/api';
 import { QUERY_KEY } from '@constants/queryKey';
-import { getRefreshToken, setLoginInfo } from '@utils/localStorage';
+import {
+  getRefreshToken,
+  setAccessToken,
+  setLoginInfo,
+} from '@utils/localStorage';
 import { useMutation, useQuery } from 'react-query';
 
-export const useCheckNickname = (nickname: string) => {
-  const { data, status, error, refetch } = useQuery(
-    [QUERY_KEY.nicknameCheck, nickname],
-    () => checkNickname(nickname),
-    {
-      enabled: false,
-      retry: false,
+export const useNicknameCheckQuery = (nickname: string) =>
+  useQuery({
+    queryKey: [QUERY_KEY.nicknameCheck, nickname],
+    queryFn: () => checkNickname(nickname),
+    enabled: false,
+    retry: false,
+  });
+
+export const useSignupMutation = () =>
+  useMutation<SignupDataFromServer, unknown, SignupData>({
+    mutationFn: (signupInfo: SignupData) => signup(signupInfo),
+    onSuccess: ({ data }) => {
+      setLoginInfo(data);
     },
-  );
-
-  return { data, status, error, refetch };
-};
-
-export const useSignup = () => {
-  const { mutate, status, error } = useMutation(
-    (userInfo: {
-      nickname: string;
-      mainLocationId: number;
-      subLocationId?: number;
-    }) => signup(userInfo),
-    {
-      onSuccess: ({ data }) => {
-        setLoginInfo(data);
-      },
-      onError: (error) => {
-        if (error instanceof Error) {
-          throw error;
-        }
-      },
+    onError: (error) => {
+      if (error instanceof Error) {
+        throw error;
+      }
     },
-  );
+  });
 
-  return { mutate, status, error };
-};
-
-export const useLogin = (
-  code: string,
-  onLogin: (
-    data:
-      | {
-          isUser: false;
-          accessToken: string;
-        }
-      | {
-          isUser: true;
-          accessToken: string;
-          refreshToken: string;
-          user: UserType;
-        },
-  ) => void,
+export const useLoginMutation = (
+  onLogin: (data: LoginDataFromServer['data']) => void,
   onLoginFail: () => void,
-) => {
-  const { mutate, status, error } = useMutation(() => login(code), {
+) =>
+  useMutation<LoginDataFromServer, unknown, string>({
+    mutationFn: (code: string) => login(code),
     onSuccess: ({ success, data }) => {
       if (!success) {
         onLoginFail();
@@ -64,34 +42,27 @@ export const useLogin = (
     },
   });
 
-  return { mutate, status, error };
-};
+export const useLogoutMutation = (onLogout: () => void) =>
+  useMutation({
+    mutationFn: () => logout(),
+    onSuccess: () => onLogout(),
+  });
 
-export const useLogout = (onLogout: () => void) => {
-  const { mutate, status, error } = useMutation(() => logout(), {
-    onSuccess: () => {
-      onLogout();
+export const useTokenRefreshQuery = () => {
+  const tokenRefreshQuery = useQuery({
+    queryKey: QUERY_KEY.tokenRefresh,
+    queryFn: () => refreshToken(),
+    refetchInterval: 1000 * 60 * 60,
+    refetchIntervalInBackground: true,
+    enabled: !!getRefreshToken(),
+    select: (data) => {
+      if (data.success) {
+        return data.data.accessToken;
+      }
     },
   });
 
-  return { mutate, status, error };
-};
-
-export const useTokenRefresh = () => {
-  const { data, status, error } = useQuery(
-    QUERY_KEY.tokenRefresh,
-    refreshToken,
-    {
-      refetchInterval: 1000 * 60 * 60,
-      refetchIntervalInBackground: true,
-      enabled: !!getRefreshToken(),
-      select: (data) => {
-        if (data.success) {
-          return data.data.accessToken;
-        }
-      },
-    },
-  );
-
-  return { data, status, error };
+  if (tokenRefreshQuery.data) {
+    setAccessToken(tokenRefreshQuery.data);
+  }
 };

--- a/fe/src/queries/auth.ts
+++ b/fe/src/queries/auth.ts
@@ -3,7 +3,7 @@ import { QUERY_KEY } from '@constants/queryKey';
 import { getRefreshToken, setAccessToken } from '@utils/localStorage';
 import { useMutation, useQuery } from 'react-query';
 
-export const useNicknameCheckQuery = (nickname: string) =>
+export const useNicknameCheck = (nickname: string) =>
   useQuery({
     queryKey: [QUERY_KEY.nicknameCheck, nickname],
     queryFn: () => checkNickname(nickname),
@@ -15,7 +15,7 @@ export const useNicknameCheckQuery = (nickname: string) =>
     retry: false,
   });
 
-export const useTokenRefreshQuery = () => {
+export const useTokenRefresh = () => {
   const tokenRefreshQuery = useQuery({
     queryKey: QUERY_KEY.tokenRefresh,
     queryFn: () => refreshToken(),
@@ -34,17 +34,17 @@ export const useTokenRefreshQuery = () => {
   }
 };
 
-export const useSignupMutation = () =>
+export const useSignup = () =>
   useMutation<SignupDataFromServer, unknown, SignupData>({
     mutationFn: (signupInfo: SignupData) => signup(signupInfo),
   });
 
-export const useLoginMutation = () =>
+export const useLogin = () =>
   useMutation<LoginDataFromServer, unknown, string>({
     mutationFn: (code: string) => login(code),
   });
 
-export const useLogoutMutation = () =>
+export const useLogout = () =>
   useMutation({
     mutationFn: () => logout(),
   });

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -11,10 +11,10 @@ import { NotFound } from './pages/NotFound';
 import { OauthLoading } from './pages/OauthLoading';
 import { Sales } from './pages/Sales';
 import { Signup } from './pages/Signup';
-import { useTokenRefreshQuery } from './queries/auth';
+import { useTokenRefresh } from './queries/auth';
 
 export const AppRoutes: React.FC = () => {
-  useTokenRefreshQuery();
+  useTokenRefresh();
 
   return (
     <div css={globalStyle} id="app-layout">

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -36,7 +36,7 @@ export const AppRoutes: React.FC = () => {
             <Route path={PATH.account} element={<Account />} />
           </Route>
         </Route>
-        <Route element={<OnlyGuestRoute />}>
+        <Route element={<OnlyNotLoginUserRoute />}>
           <Route path={PATH.redirect} element={<OauthLoading />} />
           <Route path={PATH.signup} element={<Signup />} />
         </Route>
@@ -51,7 +51,7 @@ const OnlyLoginUserRoute: React.FC = () => {
   return isLogin ? <Outlet /> : <Navigate to={PATH.account} />;
 };
 
-const OnlyGuestRoute: React.FC = () => {
+const OnlyNotLoginUserRoute: React.FC = () => {
   const { isLogin } = useAuth();
 
   return isLogin ? <Navigate to={PATH.home} /> : <Outlet />;

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -30,7 +30,7 @@ export const AppRoutes: React.FC = () => {
         {/* TODO: 하단바 O - 상세페이지 / 인증 필요*/}
         {/* TODO: 하단바 O - 채팅페이지 / 인증 필요 */}
         <Route element={<Layout />}>
-          <Route element={<PrivateRoute />}>
+          <Route element={<OnlyLoginUserRoute />}>
             <Route path={PATH.sales} element={<Sales />} />
             <Route path={PATH.interests} element={<Interests />} />
             <Route path={PATH.chat} element={<Chat />} />
@@ -41,7 +41,7 @@ export const AppRoutes: React.FC = () => {
             <Route path={PATH.auth} element={<Auth />} />
           </Route>
         </Route>
-        <Route element={<PublicRoute />}>
+        <Route element={<OnlyGuestRoute />}>
           <Route path={PATH.redirect} element={<OauthLoading />} />
           <Route path={PATH.signup} element={<Signup />} />
         </Route>
@@ -50,13 +50,13 @@ export const AppRoutes: React.FC = () => {
   );
 };
 
-const PrivateRoute: React.FC = () => {
+const OnlyLoginUserRoute: React.FC = () => {
   const { isLogin } = useAuth();
 
   return isLogin ? <Outlet /> : <Navigate to={PATH.auth} />;
 };
 
-const PublicRoute: React.FC = () => {
+const OnlyGuestRoute: React.FC = () => {
   const { isLogin } = useAuth();
 
   return isLogin ? <Navigate to={PATH.home} /> : <Outlet />;

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -4,7 +4,6 @@ import { PATH } from './constants/path';
 import { useTokenRefresh } from './queries/auth';
 import { useAuth } from './hooks/useAuth';
 import { Layout } from './layout/Layout';
-import { Auth } from './pages/Auth';
 import { Chat } from './pages/Chat';
 import { Home } from './pages/Home';
 import { Interests } from './pages/Interests';
@@ -13,6 +12,7 @@ import { OauthLoading } from './pages/OauthLoading';
 import { Sales } from './pages/Sales';
 import { Signup } from './pages/Signup';
 import { setAccessToken } from './utils/localStorage';
+import { Account } from './pages/Account';
 
 export const AppRoutes: React.FC = () => {
   const { data: tokenRefreshResult } = useTokenRefresh();
@@ -38,7 +38,7 @@ export const AppRoutes: React.FC = () => {
           <Route path={PATH.notFound} element={<NotFound />} />
           <Route>
             <Route path={PATH.home} element={<Home />} />
-            <Route path={PATH.auth} element={<Auth />} />
+            <Route path={PATH.account} element={<Account />} />
           </Route>
         </Route>
         <Route element={<OnlyGuestRoute />}>
@@ -53,7 +53,7 @@ export const AppRoutes: React.FC = () => {
 const OnlyLoginUserRoute: React.FC = () => {
   const { isLogin } = useAuth();
 
-  return isLogin ? <Outlet /> : <Navigate to={PATH.auth} />;
+  return isLogin ? <Outlet /> : <Navigate to={PATH.account} />;
 };
 
 const OnlyGuestRoute: React.FC = () => {

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import { PATH } from './constants/path';
-import { useTokenRefresh } from './queries/auth';
 import { useAuth } from './hooks/useAuth';
 import { Layout } from './layout/Layout';
+import { Account } from './pages/Account';
 import { Chat } from './pages/Chat';
 import { Home } from './pages/Home';
 import { Interests } from './pages/Interests';
@@ -11,15 +11,10 @@ import { NotFound } from './pages/NotFound';
 import { OauthLoading } from './pages/OauthLoading';
 import { Sales } from './pages/Sales';
 import { Signup } from './pages/Signup';
-import { setAccessToken } from './utils/localStorage';
-import { Account } from './pages/Account';
+import { useTokenRefreshQuery } from './queries/auth';
 
 export const AppRoutes: React.FC = () => {
-  const { data: tokenRefreshResult } = useTokenRefresh();
-
-  if (tokenRefreshResult) {
-    setAccessToken(tokenRefreshResult);
-  }
+  useTokenRefreshQuery();
 
   return (
     <div css={globalStyle} id="app-layout">

--- a/fe/src/stores/authStore.ts
+++ b/fe/src/stores/authStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type AuthState = {
+  signUpInProgress: boolean;
+  setSignUpInProgress: (signUpInProgress: boolean) => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  signUpInProgress: false,
+  setSignUpInProgress: (signUpInProgress: boolean) => set({ signUpInProgress }),
+}))

--- a/fe/src/types/type.d.ts
+++ b/fe/src/types/type.d.ts
@@ -65,3 +65,34 @@ type FetchProductsParams = {
   next?: number | null;
   size?: number | null;
 };
+
+type SignupData = {
+  nickname: string;
+  mainLocationId: number;
+  subLocationId?: number;
+};
+
+type SignupDataFromServer = {
+  success: boolean;
+  data: {
+    isUser: boolean;
+    accessToken: string;
+    refreshToken: string;
+    user: UserType;
+  };
+};
+
+type LoginDataFromServer = {
+  success: true;
+  data:
+    | {
+        isUser: true;
+        accessToken: string;
+        refreshToken: string;
+        user: UserType;
+      }
+    | {
+        isUser: false;
+        accessToken: string;
+      };
+};

--- a/fe/src/utils/localStorage.ts
+++ b/fe/src/utils/localStorage.ts
@@ -53,8 +53,8 @@ export const getTokens = () => {
   }
 
   return {
-    accessToken: getAccessToken(),
-    refreshToken: getRefreshToken(),
+    accessToken,
+    refreshToken,
   };
 };
 
@@ -70,4 +70,4 @@ export const clearTokens = () => {
 export const clearLoginInfo = () => {
   clearUserInfo();
   clearTokens();
-}
+};


### PR DESCRIPTION
## What is this PR? 👓

- 로그인, 회원가입 관련해서 피드백 받은 사항을 리팩토링했습니다.

## Key changes 🔑

- `SignUp` : 닉네임 훅을 사용해서 회원가입이 닉네임 관련 로직을 신경쓰지 않고 필요한 값을 사용할 수 있도록 했습니다.
- `queries/auth` : 로그인, 회원가입 관련 query, mutation 형태를 공식문서 & 깃헙 참고해서 수정했습니다
  - return 할 값들을 제한하지 않고 useQuery, useMutation을 그대로 반환했습니다. 추후 필요한 값이 있다면 사용처에서 디스트럭처링해서 사용하면 됩니다.
- onSuccess 콜백을 useMutation 대신 mutate를 호출하면서 전달합니다.
  - 실제 함수 사용처에서 onSuccess or onError를 넘겨 의도를 파악하기 용이하도록 했습니다.
- useAuthStore(zustand Store)를 사용해서 URL 직접 입력으로 페이지로 진입하는 것을 제한했습니다.
  - 기존 방식: route state
- `Dropdown` : Context API 제거 
- `PrivateRoute`, `PublicRoute` 을 의미가 드러나도록 이름 변경

## To reviewers 👋

- use**Query, use**Mutation 등으로 리액트 쿼리 관련 훅 네이밍 하는 것은 불필요하다는 피드백을 받아 반영하지 않았습니다.
- 폴더가 너무 많아져서 정리가 필요할 것 같습니다. query 디렉토리를 hooks 안에 넣는 것은 어떠신가요? 
- Dropdown의 autoClose prop이 제거되었으니, 사용에 유의해주세요. 대신, 백드롭이나 메뉴를 클릭하면 무조건 닫힙니다.