### PR TITLE
상품 등록 페이지 기능 구현

### DIFF
--- a/fe/src/api/api.ts
+++ b/fe/src/api/api.ts
@@ -150,3 +150,16 @@ export const getProductsDetail = (id: number) => {
     },
   });
 };
+
+export const requestImageUpload = (image: FormData) => {
+  return fetchData(END_POINT.imageUpload, {
+    method: 'POST',
+    headers: {
+      "Content-Type": "multipart/form-data",
+      Authorization: `Bearer ${getAccessToken()}`,
+    },
+    body: JSON.stringify({
+      image
+    })
+  })
+}

--- a/fe/src/api/api.ts
+++ b/fe/src/api/api.ts
@@ -151,16 +151,13 @@ export const getProductsDetail = (id: number) => {
   });
 };
 
-export const requestImageUpload = (image: FormData) => {
+export const requestImageUpload = (images: FormData) => {
   return fetchData(END_POINT.imageUpload, {
     method: 'POST',
     headers: {
-      'Content-Type': 'multipart/form-data',
       Authorization: `Bearer ${getAccessToken()}`,
     },
-    body: JSON.stringify({
-      image,
-    }),
+    body: images,
   });
 };
 
@@ -168,6 +165,7 @@ export const addNewProduct = (productFormData: ProductFormData) => {
   return fetchData(END_POINT.products(), {
     method: 'POST',
     headers: {
+      'Content-Type': 'application/json',
       Authorization: `Bearer ${getAccessToken()}`,
     },
     body: JSON.stringify(productFormData),

--- a/fe/src/api/api.ts
+++ b/fe/src/api/api.ts
@@ -155,11 +155,21 @@ export const requestImageUpload = (image: FormData) => {
   return fetchData(END_POINT.imageUpload, {
     method: 'POST',
     headers: {
-      "Content-Type": "multipart/form-data",
+      'Content-Type': 'multipart/form-data',
       Authorization: `Bearer ${getAccessToken()}`,
     },
     body: JSON.stringify({
-      image
-    })
-  })
-}
+      image,
+    }),
+  });
+};
+
+export const addNewProduct = (productFormData: ProductFormData) => {
+  return fetchData(END_POINT.products(), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${getAccessToken()}`,
+    },
+    body: JSON.stringify(productFormData),
+  });
+};

--- a/fe/src/components/common/input/TextArea.tsx
+++ b/fe/src/components/common/input/TextArea.tsx
@@ -1,15 +1,47 @@
 import { Theme, css } from '@emotion/react';
+import React, { useEffect, useMemo, useRef } from 'react';
 
-type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+type Props = {
+  onChange: (value: string) => void;
+  minRows?: number;
+} & Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'onChange'>;
 
-export const TextArea: React.FC<Props> = ({ ...rest }) => {
-  return <textarea css={(theme) => textAreaStyle(theme)} {...rest} />;
+export const TextArea: React.FC<Props> = ({
+  onChange,
+  minRows = 1,
+  ...rest
+}) => {
+  const minHeight = useMemo(() => minRows * 24, [minRows]);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    textarea.style.height = 'auto';
+    textarea.style.height = `${Math.max(textarea.scrollHeight, minHeight)}px`;
+  }, [rest.value, minHeight]);
+
+  const onChangeTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = e.target;
+
+    onChange(value);
+  };
+
+  return (
+    <textarea
+      css={(theme) => textAreaStyle(theme)}
+      {...rest}
+      ref={textareaRef}
+      onChange={onChangeTextarea}
+    />
+  );
 };
 
 const textAreaStyle = (theme: Theme) => css`
   width: 100%;
-  height: 200px;
   font: ${theme.font.availableDefault16};
+  caret-color: ${theme.color.accent.backgroundSecondary};
 
   &::placeholder {
     color: ${theme.color.neutral.textWeak};

--- a/fe/src/components/common/modal/categoryModal/CategoryModal.tsx
+++ b/fe/src/components/common/modal/categoryModal/CategoryModal.tsx
@@ -1,54 +1,43 @@
-import { usePopupStore } from '@stores/popupStore';
 import { Modal } from '@components/common/modal/Modal';
 import { ModalHeader } from '@components/common/modal/ModalHeader';
 import { ModalListItem } from '@components/common/modal/ModalListItem';
+import { usePopupStore } from '@stores/popupStore';
 
-export const CategoryModal: React.FC = () => {
+type Props = {
+  categoryList?: CategoryType[];
+  onSelectCategory: (id: number) => void;
+};
+
+export const CategoryModal: React.FC<Props> = ({
+  categoryList,
+  onSelectCategory,
+}) => {
   const { isOpen, currentDim, togglePopup, setCurrentDim } = usePopupStore();
-
-  const onSelectCategory = (id: number) => {
-    console.log('카테고리 선택:', id);
-  };
 
   const onCloseModal = () => {
     togglePopup('modal', false);
     setCurrentDim(null);
   };
 
-  // TODO mock data 교체 필요
-  const modalList = [
-    { id: 0, text: '여성잡화' },
-    { id: 1, text: '남성패션/잡화' },
-    { id: 2, text: '뷰티/미용' },
-    { id: 3, text: '스포츠/레저' },
-    { id: 4, text: '취미/게임/음반' },
-    { id: 5, text: '중고차' },
-    { id: 6, text: '티켓/교환권' },
-    { id: 7, text: '가공식품' },
-    { id: 8, text: '반려동물용품' },
-    { id: 9, text: '식물' },
-    { id: 10, text: '기타 중고물품' },
-    { id: 11, text: '기타 중고물품' },
-    { id: 12, text: '기타 중고물품' },
-    { id: 13, text: '기타 중고물품' },
-    { id: 14, text: '기타 중고물품' },
-  ];
-
   return (
     <Modal isOpen={isOpen.modal} currentDim={currentDim}>
       <ModalHeader title="카테고리" onCloseModal={onCloseModal} />
-      <ul>
-        {modalList.map((item) => (
-          <ModalListItem
-            name={item.text} // TODO props: data에 따라 수정
-            key={item.id}
-            onClick={() => {
-              onSelectCategory(item.id);
-              onCloseModal();
-            }}
-          />
-        ))}
-      </ul>
+      {!categoryList ? (
+        <div>...카테고리 로딩중</div>
+      ) : (
+        <ul>
+          {categoryList.map((category) => (
+            <ModalListItem
+              name={category.name} // TODO props: data에 따라 수정
+              key={category.id}
+              onClick={() => {
+                onSelectCategory(category.id);
+                onCloseModal();
+              }}
+            />
+          ))}
+        </ul>
+      )}
     </Modal>
   );
 };

--- a/fe/src/components/common/modal/locationModal/LocationModal.tsx
+++ b/fe/src/components/common/modal/locationModal/LocationModal.tsx
@@ -1,11 +1,11 @@
-import { usePopupStore } from '@stores/popupStore';
+import { useAuth } from '@/hooks/useAuth';
+import { useDeleteLocation, usePatchMainLocation } from '@/queries/location';
+import { useRegisteredLocationsStore } from '@/stores/locationStore';
 import { Modal } from '@components/common/modal/Modal';
+import { usePopupStore } from '@stores/popupStore';
 import { useState } from 'react';
 import { ControlLocation } from './content/ControlLocation';
 import { SearchLocation } from './content/SearchLocation';
-import { useDeleteLocation, usePatchMainLocation } from '@/queries/location';
-import { useRegisteredLocationsStore } from '@/stores/locationStore';
-import { useAuth } from '@/hooks/useAuth';
 
 type Props = {
   locationList?: LocationType[];

--- a/fe/src/components/new/CategorySelector.tsx
+++ b/fe/src/components/new/CategorySelector.tsx
@@ -1,0 +1,70 @@
+import { useCategoryExample } from '@/hooks/useCategoryExample';
+import { usePopupStore } from '@/stores/popupStore';
+import { Theme, css } from '@emotion/react';
+import { Button } from '../common/button/Button';
+import { ChevronRight } from '../common/icons';
+
+type Props = {
+  categories?: CategoryType[];
+  selectedCategory?: CategoryType;
+  onSelectCategory: (id: number) => void;
+};
+
+export const CategorySelector: React.FC<Props> = ({
+  categories,
+  selectedCategory,
+  onSelectCategory,
+}: Props) => {
+  const { categoryExamples } = useCategoryExample({
+    categories,
+    selectedCategory,
+  });
+  const { togglePopup, setCurrentDim } = usePopupStore();
+
+  if (!categories) {
+    return <div>...카테고리 로딩중</div>;
+  }
+
+  const openCategoryModal = () => {
+    togglePopup('modal', true);
+    setCurrentDim('modal');
+  };
+
+  return (
+    <div css={(theme) => categorySelectorStyle(theme)}>
+      <ul className="categories__container">
+        {categoryExamples.map((category) => (
+          <li key={category.id}>
+            <Button
+              variant="category"
+              state={
+                selectedCategory?.id === category.id ? 'active' : 'default'
+              }
+              onClick={() => onSelectCategory(category.id)}
+            >
+              {category.name}
+            </Button>
+          </li>
+        ))}
+      </ul>
+      <Button variant="text" className="more-btn" onClick={openCategoryModal}>
+        <ChevronRight />
+      </Button>
+    </div>
+  );
+};
+
+const categorySelectorStyle = (theme: Theme) => css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .categories__container {
+    display: flex;
+    gap: 4px;
+  }
+
+  .more-btn > svg {
+    stroke: ${theme.color.neutral.textStrong};
+  }
+`;

--- a/fe/src/components/new/CategorySelector.tsx
+++ b/fe/src/components/new/CategorySelector.tsx
@@ -61,6 +61,7 @@ const categorySelectorStyle = (theme: Theme) => css`
 
   .categories__container {
     display: flex;
+    align-items: center;
     gap: 4px;
   }
 

--- a/fe/src/components/new/ImageInput.tsx
+++ b/fe/src/components/new/ImageInput.tsx
@@ -1,0 +1,141 @@
+import { useImageUpload } from '@/queries/products';
+import { css, Theme } from '@emotion/react';
+import { useRef, useState } from 'react';
+import { Camera } from '../common/icons';
+import { ImageItem } from './ImageItem';
+
+export const ImageInput: React.FC = () => {
+  const [pictureList, setPictureList] = useState<{ id: number; url: string }[]>(
+    [],
+  );
+  const imageMutation = useImageUpload();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const addImage = () => {
+    if (pictureList.length >= 10) {
+      return;
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  const onChangeFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    // 파일이 없으면 업로드 하지 않음
+    if (!file) {
+      return;
+    }
+
+    // 허용한 타입이 아니거나 용량이 2MB를 초과하면 업로드 하지 않음
+    const allowedTypes = ['image/png', 'image/jpg', 'image/jpeg'];
+    const volumeLimit = 1024 * 1024 * 2; // 2MB
+
+    console.log('type', file.type);
+    console.log('size', file.size / volumeLimit);
+
+    if (!allowedTypes.includes(file.type) || file.size > volumeLimit) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('image', file);
+
+    imageMutation.mutate(formData, {
+      onSuccess: (result) => {
+        if (result.success) {
+          setPictureList([
+            ...pictureList,
+            { id: result.data.imageId, url: result.data.imageUrl },
+          ]);
+        }
+      },
+      onError: (error) => {
+        if (error instanceof Error) {
+          throw error;
+        }
+      },
+    });
+  };
+
+  return (
+    <div css={(theme) => pictureInputStype(theme)}>
+      <div className="picture__container">
+        <button
+          className="picture__add-btn"
+          onClick={addImage}
+          disabled={pictureList.length >= 10}
+        >
+          <Camera />
+          <span>{pictureList.length}/10</span>
+        </button>
+        <input
+          type="file"
+          accept=".png, .jpg, .jpeg"
+          className="picture__file-input"
+          ref={fileInputRef}
+          onChange={onChangeFileInput}
+        />
+        {pictureList.map((picture, index) => (
+          <ImageItem
+            key={picture.id}
+            size="m"
+            imageUrl={picture.url}
+            label={index === 0 ? '대표 사진' : ''}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const pictureInputStype = (theme: Theme) => css`
+  padding-top: 8px;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  & .picture {
+    &__container {
+      display: flex;
+      gap: 16px;
+    }
+
+    &__add-btn {
+      flex-shrink: 0;
+      width: 80px;
+      height: 80px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 4px;
+      border-radius: 16px;
+      border: 0.8px solid ${theme.color.neutral.border};
+
+      & > svg {
+        stroke: ${theme.color.neutral.textStrong};
+      }
+
+      &:hover,
+      &:active {
+        opacity: 0.8;
+      }
+
+      &:disabled {
+        cursor: default;
+        opacity: 0.32;
+      }
+    }
+
+    &__file-input {
+      display: none;
+    }
+  }
+`;

--- a/fe/src/components/new/ImageInput.tsx
+++ b/fe/src/components/new/ImageInput.tsx
@@ -10,7 +10,11 @@ type Props = {
   onDeleteImage: (image: ImageType) => void;
 };
 
-export const ImageInput: React.FC<Props> = ({ imageList, onAddImage,  onDeleteImage}) => {
+export const ImageInput: React.FC<Props> = ({
+  imageList,
+  onAddImage,
+  onDeleteImage,
+}) => {
   const imageMutation = useImageUpload();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -25,28 +29,40 @@ export const ImageInput: React.FC<Props> = ({ imageList, onAddImage,  onDeleteIm
   };
 
   const uploadImageFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+    const files = e.target.files;
 
     // 파일이 없으면 업로드 하지 않음
-    if (!file) {
+    if (!files) {
       return;
     }
 
-    // 허용한 타입이 아니거나 용량이 2MB를 초과하면 업로드 하지 않음
-    const allowedTypes = ['image/png', 'image/jpg', 'image/jpeg'];
-    const volumeLimit = 1024 * 1024 * 2; // 2MB
-
-    if (!allowedTypes.includes(file.type) || file.size > volumeLimit) {
+    if (files.length + imageList.length > 10) {
+      alert('이미지는 최대 10개까지 업로드 할 수 있습니다.');
       return;
+    }
+
+    for (const file of files) {
+      // 허용한 타입이 아니거나 용량이 2MB를 초과하면 업로드 하지 않음
+      const allowedTypes = ['image/png', 'image/jpg', 'image/jpeg'];
+      const VOLUME_LIMIT = 1024 * 1024 * 2; // 2MB
+
+      if (!allowedTypes.includes(file.type) || file.size > VOLUME_LIMIT) {
+        alert('이미지는 2MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.');
+        return;
+      }
     }
 
     const formData = new FormData();
-    formData.append('image', file);
+    for (const file of files) {
+      formData.append('images', file);
+    }
 
     imageMutation.mutate(formData, {
       onSuccess: (result) => {
         if (result.success) {
-          onAddImage(result.data);
+          result.data.forEach((image) => {
+            onAddImage(image);
+          });
         }
       },
       onError: (error) => {
@@ -75,22 +91,24 @@ export const ImageInput: React.FC<Props> = ({ imageList, onAddImage,  onDeleteIm
         </button>
         <input
           type="file"
+          multiple
           accept=".png, .jpg, .jpeg"
           className="image-input__file-input"
           ref={fileInputRef}
           onChange={uploadImageFile}
         />
         <ul className="image-input__image-list">
-          {imageList.map((image, index) => (
-            <li key={image.imageId}>
-              <ImageItem
-                size="m"
-                imageUrl={image.imageUrl}
-                label={index === 0 ? '대표 사진' : ''}
-                onClick={() => onDeleteImage(image)}
-              />
-            </li>
-          ))}
+          {imageList &&
+            imageList.map((image, index) => (
+              <li key={image.imageId}>
+                <ImageItem
+                  size="m"
+                  imageUrl={image.imageUrl}
+                  label={index === 0 ? '대표 사진' : ''}
+                  onClick={() => onDeleteImage(image)}
+                />
+              </li>
+            ))}
         </ul>
       </div>
     </div>

--- a/fe/src/components/new/ImageInput.tsx
+++ b/fe/src/components/new/ImageInput.tsx
@@ -1,11 +1,16 @@
 import { useImageUpload } from '@/queries/products';
 import { css, Theme } from '@emotion/react';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { Camera } from '../common/icons';
 import { ImageItem } from './ImageItem';
 
-export const ImageInput: React.FC = () => {
-  const [imageList, setImageList] = useState<ImageData[]>([]);
+type Props = {
+  imageList: ImageType[];
+  onAddImage: (image: ImageType) => void;
+  onDeleteImage: (image: ImageType) => void;
+};
+
+export const ImageInput: React.FC<Props> = ({ imageList, onAddImage,  onDeleteImage}) => {
   const imageMutation = useImageUpload();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -41,7 +46,7 @@ export const ImageInput: React.FC = () => {
     imageMutation.mutate(formData, {
       onSuccess: (result) => {
         if (result.success) {
-          setImageList([...imageList, result.data]);
+          onAddImage(result.data);
         }
       },
       onError: (error) => {
@@ -55,10 +60,6 @@ export const ImageInput: React.FC = () => {
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-  };
-
-  const deleteImage = (id: number) => {
-    setImageList((i) => i.filter((image) => image.imageId !== id));
   };
 
   return (
@@ -80,13 +81,13 @@ export const ImageInput: React.FC = () => {
           onChange={uploadImageFile}
         />
         <ul className="image-input__image-list">
-          {imageList.map(({ imageId, imageUrl }, index) => (
-            <li key={imageId}>
+          {imageList.map((image, index) => (
+            <li key={image.imageId}>
               <ImageItem
                 size="m"
-                imageUrl={imageUrl}
+                imageUrl={image.imageUrl}
                 label={index === 0 ? '대표 사진' : ''}
-                onClick={() => deleteImage(imageId)}
+                onClick={() => onDeleteImage(image)}
               />
             </li>
           ))}

--- a/fe/src/components/new/ImageItem.tsx
+++ b/fe/src/components/new/ImageItem.tsx
@@ -4,17 +4,13 @@ import { ImageBox, ImageBoxProps } from '../common/imageBox/ImageBox';
 
 type Props = {
   label?: string;
+  onClick?: () => void;
 } & ImageBoxProps;
 
-export const ImageItem: React.FC<Props> = ({
-  label,
-  variant,
-  size,
-  imageUrl,
-}) => {
+export const ImageItem: React.FC<Props> = ({ label, onClick, ...rest }) => {
   return (
-    <div css={(theme) => pictureItemStyle(theme)}>
-      <ImageBox variant={variant} size={size} imageUrl={imageUrl} />
+    <div css={(theme) => pictureItemStyle(theme)} onClick={onClick}>
+      <ImageBox {...rest} />
       <button type="button" className="picture-item__remove-btn">
         <BezeledX />
       </button>
@@ -50,5 +46,11 @@ const pictureItemStyle = (theme: Theme) => css`
     background: ${theme.color.neutral.overlay};
     font: ${theme.font.displayDefault12};
     color: ${theme.color.neutral.background};
+  }
+
+  &:hover,
+  &:active {
+    opacity: 0.8;
+    cursor: pointer;
   }
 `;

--- a/fe/src/components/new/ImageItem.tsx
+++ b/fe/src/components/new/ImageItem.tsx
@@ -1,12 +1,12 @@
 import { Theme, css } from '@emotion/react';
-import { BezeledX } from '../icons';
-import { ImageBox, ImageBoxProps } from './ImageBox';
+import { BezeledX } from '../common/icons';
+import { ImageBox, ImageBoxProps } from '../common/imageBox/ImageBox';
 
 type Props = {
   label?: string;
 } & ImageBoxProps;
 
-export const PictureItem: React.FC<Props> = ({
+export const ImageItem: React.FC<Props> = ({
   label,
   variant,
   size,

--- a/fe/src/components/new/LocationSelector.tsx
+++ b/fe/src/components/new/LocationSelector.tsx
@@ -1,0 +1,84 @@
+import { useAnimation } from '@/hooks/useAnimation';
+import { Theme, css } from '@emotion/react';
+import { useState } from 'react';
+import { Button } from '../common/button/Button';
+import { MapPinFilled } from '../common/icons';
+
+type Props = {
+  selectedLocation?: LocationType;
+  locations?: LocationType[];
+  onSelectLocation: (location: LocationType) => void;
+};
+
+export const LocationSelector: React.FC<Props> = ({
+  selectedLocation,
+  locations,
+  onSelectLocation,
+}) => {
+  const [isListOpen, setIsListOpen] = useState(false);
+  const { shouldRender, handleTransitionEnd, animationTrigger } =
+    useAnimation(isListOpen);
+
+  const openLocationContainer = () => {
+    setIsListOpen(true);
+  };
+
+  const onSelectLocationButton = (locaiton: LocationType) => {
+    onSelectLocation(locaiton);
+    setIsListOpen(false);
+  };
+
+  return (
+    <div css={(theme) => locationSelectorStyle(theme, animationTrigger)}>
+      <Button variant="text" onClick={openLocationContainer}>
+        <MapPinFilled className="location__pin-icon" />
+        {selectedLocation?.name}
+      </Button>
+      {locations && shouldRender && (
+        <ul
+          className="location__container"
+          onTransitionEnd={handleTransitionEnd}
+        >
+          {locations.map((location) => (
+            <li key={location.id}>
+              <Button
+                variant="category"
+                state={
+                  selectedLocation?.id === location.id ? 'active' : 'default'
+                }
+                onClick={() => onSelectLocationButton(location)}
+              >
+                {location.name}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const locationSelectorStyle = (theme: Theme, animationTrigger: boolean) => css`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  .location__pin-icon {
+    fill: ${theme.color.neutral.textStrong};
+  }
+
+  .location__container {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    ${animationTrigger ? '' : 'transform: translateY(100%);'};
+    background-color: ${theme.color.neutral.backgroundWeak};
+    transition: 200ms ease;
+  }
+`;

--- a/fe/src/components/new/LocationSelector.tsx
+++ b/fe/src/components/new/LocationSelector.tsx
@@ -2,7 +2,7 @@ import { useAnimation } from '@/hooks/useAnimation';
 import { Theme, css } from '@emotion/react';
 import { useState } from 'react';
 import { Button } from '../common/button/Button';
-import { MapPinFilled } from '../common/icons';
+import { MapPinFilled, X } from '../common/icons';
 
 type Props = {
   selectedLocation?: LocationType;
@@ -15,17 +15,21 @@ export const LocationSelector: React.FC<Props> = ({
   locations,
   onSelectLocation,
 }) => {
-  const [isListOpen, setIsListOpen] = useState(false);
+  const [isContainerOpen, setIsContainerOpen] = useState(false);
   const { shouldRender, handleTransitionEnd, animationTrigger } =
-    useAnimation(isListOpen);
+    useAnimation(isContainerOpen);
 
   const openLocationContainer = () => {
-    setIsListOpen(true);
+    setIsContainerOpen(true);
   };
 
-  const onSelectLocationButton = (locaiton: LocationType) => {
-    onSelectLocation(locaiton);
-    setIsListOpen(false);
+  const closeLocationContainer = () => {
+    setIsContainerOpen(false);
+  };
+
+  const onSelectLocationButton = (location: LocationType) => {
+    onSelectLocation(location);
+    closeLocationContainer();
   };
 
   return (
@@ -35,24 +39,29 @@ export const LocationSelector: React.FC<Props> = ({
         {selectedLocation?.name}
       </Button>
       {locations && shouldRender && (
-        <ul
-          className="location__container"
-          onTransitionEnd={handleTransitionEnd}
-        >
-          {locations.map((location) => (
-            <li key={location.id}>
-              <Button
-                variant="category"
-                state={
-                  selectedLocation?.id === location.id ? 'active' : 'default'
-                }
-                onClick={() => onSelectLocationButton(location)}
-              >
-                {location.name}
-              </Button>
-            </li>
-          ))}
-        </ul>
+        <div className="location__container">
+          <ul
+            className="location__container--location-btns"
+            onTransitionEnd={handleTransitionEnd}
+          >
+            {locations.map((location) => (
+              <li key={location.id}>
+                <Button
+                  variant="category"
+                  state={
+                    selectedLocation?.id === location.id ? 'active' : 'default'
+                  }
+                  onClick={() => onSelectLocationButton(location)}
+                >
+                  {location.name}
+                </Button>
+              </li>
+            ))}
+          </ul>
+          <Button variant="text" onClick={closeLocationContainer} className="location__container--close-btn">
+            <X />
+          </Button>
+        </div>
       )}
     </div>
   );
@@ -76,9 +85,21 @@ const locationSelectorStyle = (theme: Theme, animationTrigger: boolean) => css`
     top: 0;
     display: flex;
     align-items: center;
-    gap: 8px;
+    justify-content: space-between;
     ${animationTrigger ? '' : 'transform: translateY(100%);'};
     background-color: ${theme.color.neutral.backgroundWeak};
     transition: 200ms ease;
+
+    &--location-btns {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    &--close-btn > svg {
+      stroke: ${theme.color.neutral.textWeak};
+    }
   }
 `;

--- a/fe/src/constants/path.ts
+++ b/fe/src/constants/path.ts
@@ -22,7 +22,7 @@ export const END_POINT = {
   logout: `/api/users/logout`,
   refreshToken: `/api/users/reissue-access-token`,
   categories: `/api/categories`,
-  products: (query: string) => `/api/products?${query}`,
+  products: (query?: string) => `/api/products${query ? `?${query}` : ''}`,
   imageUpload: `/api/images`,
 };
 

--- a/fe/src/constants/path.ts
+++ b/fe/src/constants/path.ts
@@ -23,6 +23,7 @@ export const END_POINT = {
   refreshToken: `/api/users/reissue-access-token`,
   categories: `/api/categories`,
   products: (query: string) => `/api/products?${query}`,
+  imageUpload: `/api/images`,
 };
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${

--- a/fe/src/constants/path.ts
+++ b/fe/src/constants/path.ts
@@ -12,16 +12,18 @@ export const PATH = {
 };
 
 export const END_POINT = {
-  locations: (id?: number) => id ?  `/api/users/locations/${id}` : '/api/users/locations',
+  locations: (id?: number) =>
+    id ? `/api/users/locations/${id}` : '/api/users/locations',
   locationsOf: (query: string) => `/api/locations?keyword=${query}`,
-  nicknameCheck: (nickname: string) => `/api/users/nickname?nickname=${nickname}`,
+  nicknameCheck: (nickname: string) =>
+    `/api/users/nickname?nickname=${nickname}`,
   signup: `/api/users/signup`,
   login: `/api/users/login`,
   logout: `/api/users/logout`,
   refreshToken: `/api/users/reissue-access-token`,
   categories: `/api/categories`,
-  products: (query: string) => `/api/products/${query}`,
-}
+  products: (query: string) => `/api/products?${query}`,
+};
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${
   import.meta.env.VITE_KAKAO_REST_API_KEY

--- a/fe/src/hooks/useCategoryExample.ts
+++ b/fe/src/hooks/useCategoryExample.ts
@@ -1,0 +1,54 @@
+import { getRandomElementsFromArray } from '@/utils/getRandomElementsFromArray';
+import { useEffect, useState } from 'react';
+
+type CategoryExampleType = {
+  categories?: CategoryType[];
+  selectedCategory?: CategoryType;
+};
+
+export const useCategoryExample = ({
+  categories,
+  selectedCategory,
+}: CategoryExampleType) => {
+  const [categoryExamples, setCategoryExamples] = useState<CategoryType[]>([]);
+
+  useEffect(() => {
+    if (!categories) {
+      return;
+    }
+
+    if (!selectedCategory && categoryExamples.length === 0) {
+      const randomCategories = getRandomElementsFromArray({
+        array: categories,
+        count: 3,
+      });
+      setCategoryExamples(randomCategories);
+      return;
+    }
+
+    if (selectedCategory && categoryExamples.length === 0) {
+      const randomCategories = getRandomElementsFromArray({
+        array: categories.filter(
+          (category) => category.id !== selectedCategory.id,
+        ),
+        count: 2,
+      });
+      setCategoryExamples([selectedCategory, ...randomCategories]);
+    }
+
+    if (selectedCategory && categoryExamples.length > 0) {
+      const isSelectedCategoryInExamples = categoryExamples.some(
+        (example) => example.id === selectedCategory.id,
+      );
+      if (isSelectedCategoryInExamples) {
+        return;
+      }
+
+      setCategoryExamples([selectedCategory, ...categoryExamples.slice(0, 2)]);
+    }
+  }, [categories, selectedCategory, categoryExamples]);
+
+  return {
+    categoryExamples,
+  };
+};

--- a/fe/src/hooks/useCategorySelector.ts
+++ b/fe/src/hooks/useCategorySelector.ts
@@ -1,0 +1,40 @@
+import { useCategories } from '@/queries/category';
+import { useEffect, useState } from 'react';
+
+type CategorySelectorType = {
+  initialCategoryName?: string;
+};
+
+export const useCategorySelector = ({
+  initialCategoryName,
+}: CategorySelectorType) => {
+  const [selectedCategory, setSelectedCategory] = useState<CategoryType>();
+  const { categories } = useCategories();
+
+  useEffect(() => {
+    if (!categories || !initialCategoryName) {
+      return;
+    }
+
+    const initialCategory = categories.find(
+      (category) => category.name === initialCategoryName,
+    )!;
+
+    setSelectedCategory(initialCategory);
+  }, [categories, initialCategoryName]);
+
+  const selectCategory = (id: number) => {
+    if (!categories) {
+      return;
+    }
+
+    const category = categories.find((category) => category.id === id)!;
+    setSelectedCategory(category);
+  };
+
+  return {
+    selectedCategory,
+    categories,
+    selectCategory,
+  };
+};

--- a/fe/src/hooks/useInput.ts
+++ b/fe/src/hooks/useInput.ts
@@ -32,10 +32,6 @@ export const useInput = <T>(props: InputType<T>): InputReturnType<T> => {
   const isValidValue = props.validator(value);
 
   const onChangeValue = (value: T) => {
-    if (!props.validator(value)) {
-      return;
-    }
-
     setValue(value);
   };
 

--- a/fe/src/hooks/useInput.ts
+++ b/fe/src/hooks/useInput.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-type InputType<T> =
+export type InputType<T> =
   | {
       initialValue: T;
     }
@@ -10,33 +10,39 @@ type InputType<T> =
       validator: (value: T) => boolean;
     };
 
-type ReturnType<T> = {
+export type InputReturnType<T> = {
   value: T;
   onChangeValue: (value: T) => void;
   isValidValue: boolean;
   warningMessage: string;
 };
 
-export const useInput = <T>(props: InputType<T>): ReturnType<T> => {
+export const useInput = <T>(props: InputType<T>): InputReturnType<T> => {
   const [value, setValue] = useState(props.initialValue);
 
-  const onChangeValue = (value: T) => {
-    setValue(value);
-  };
-
-  if ('validator' in props) {
+  if (!('validator' in props)) {
     return {
       value,
-      onChangeValue,
-      isValidValue: props.validator(value),
-      warningMessage: props.warningMessage,
+      onChangeValue: (value: T) => setValue(value),
+      isValidValue: true,
+      warningMessage: '',
     };
   }
+
+  const isValidValue = props.validator(value);
+
+  const onChangeValue = (value: T) => {
+    if (!props.validator(value)) {
+      return;
+    }
+
+    setValue(value);
+  };
 
   return {
     value,
     onChangeValue,
-    isValidValue: true,
-    warningMessage: '',
+    isValidValue,
+    warningMessage: isValidValue ? '' : props.warningMessage,
   };
 };

--- a/fe/src/hooks/useInput.ts
+++ b/fe/src/hooks/useInput.ts
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+type InputType<T> =
+  | {
+      initialValue: T;
+    }
+  | {
+      initialValue: T;
+      warningMessage: string;
+      validator: (value: T) => boolean;
+    };
+
+type ReturnType<T> = {
+  value: T;
+  onChangeValue: (value: T) => void;
+  isValidValue: boolean;
+  warningMessage: string;
+};
+
+export const useInput = <T>(props: InputType<T>): ReturnType<T> => {
+  const [value, setValue] = useState(props.initialValue);
+
+  const onChangeValue = (value: T) => {
+    setValue(value);
+  };
+
+  if ('validator' in props) {
+    return {
+      value,
+      onChangeValue,
+      isValidValue: props.validator(value),
+      warningMessage: props.warningMessage,
+    };
+  }
+
+  return {
+    value,
+    onChangeValue,
+    isValidValue: true,
+    warningMessage: '',
+  };
+};

--- a/fe/src/hooks/useLocationSelector.ts
+++ b/fe/src/hooks/useLocationSelector.ts
@@ -1,0 +1,40 @@
+import { useAuth } from '@/hooks/useAuth';
+import { useMyLocations } from '@/queries/location';
+import { useEffect, useState } from 'react';
+
+type LocationSelectorType = {
+  initialLocation?: LocationType;
+}
+
+export const useLocationSelector = ({ initialLocation }: LocationSelectorType) => {
+  const [selectedLocation, setSelectedLocation] = useState<LocationType | undefined>(initialLocation);
+  const { isLogin } = useAuth();
+  const { serverLocations } = useMyLocations(isLogin);
+
+  useEffect(() => {
+    // 사용자 동네를 못 가져오거나, 이미 선택된 동네가 있으면 return
+    if (!serverLocations || selectedLocation) {
+      return;
+    }
+
+    const mainLocation = serverLocations.find(
+      (location) => location.isMainLocation,
+    );
+
+    if (!mainLocation) {
+      return;
+    }
+
+    setSelectedLocation(mainLocation);
+  }, [serverLocations, selectedLocation]);
+
+  const selectLocation = (location: LocationType) => {
+    setSelectedLocation(location);
+  };
+
+  return {
+    selectedLocation,
+    selectLocation,
+    locations: serverLocations,
+  };
+};

--- a/fe/src/hooks/usePrice.ts
+++ b/fe/src/hooks/usePrice.ts
@@ -1,0 +1,40 @@
+import { useInput } from './useInput';
+
+type PriceInputReturnType = {
+  price: string;
+  isValidPrice: boolean;
+  priceWarningMessage: string;
+  onChangePrice: (price: string) => void;
+};
+
+export const usePrice = (initialPrice: string = ''): PriceInputReturnType => {
+  const { value, onChangeValue, isValidValue, warningMessage } = useInput({
+    initialValue: initialPrice,
+    validator: (value: string) => /^[0-9,]*$/.test(value),
+    warningMessage: '숫자와 쉼표(,)만 입력 가능합니다.',
+  });
+
+  const priceValidator = (price: string) => /^[0-9]$/.test(price);
+
+  const onChangePrice = (price: string) => {
+    if (price === '') {
+      onChangeValue(price);
+      return;
+    }
+
+    const priceWithoutComma = price.replace(/,/g, '');
+
+    if (!priceValidator(priceWithoutComma) || priceWithoutComma.length > 10) {
+      return;
+    }
+
+    onChangeValue(Number(priceWithoutComma).toLocaleString());
+  };
+
+  return {
+    price: value,
+    isValidPrice: isValidValue,
+    priceWarningMessage: warningMessage,
+    onChangePrice,
+  };
+};

--- a/fe/src/hooks/usePrice.ts
+++ b/fe/src/hooks/usePrice.ts
@@ -1,5 +1,9 @@
 import { useInput } from './useInput';
 
+type PriceInputType = {
+  initialPrice?: string;
+};
+
 type PriceInputReturnType = {
   price: string;
   isValidPrice: boolean;
@@ -7,9 +11,11 @@ type PriceInputReturnType = {
   onChangePrice: (price: string) => void;
 };
 
-export const usePrice = (initialPrice: string = ''): PriceInputReturnType => {
+export const usePrice = ({
+  initialPrice,
+}: PriceInputType): PriceInputReturnType => {
   const { value, onChangeValue, isValidValue, warningMessage } = useInput({
-    initialValue: initialPrice,
+    initialValue: initialPrice ?? '',
     validator: (value: string) => /^[0-9,]*$/.test(value), // 숫자와 쉼표(,)만 입력 가능
     warningMessage: '숫자와 쉼표(,)만 입력 가능합니다.',
   });
@@ -18,14 +24,14 @@ export const usePrice = (initialPrice: string = ''): PriceInputReturnType => {
   const priceValidator = (price: string) => /^[0-9]*$/.test(price);
 
   const onChangePrice = (price: string) => {
-    if (price === '') {
+    const priceWithoutComma = price.replace(/,/g, '');
+
+    if (price.length === 0 || !priceValidator(priceWithoutComma)) {
       onChangeValue(price);
       return;
     }
 
-    const priceWithoutComma = price.replace(/,/g, '');
-
-    if (!priceValidator(priceWithoutComma) || priceWithoutComma.length > 10) {
+    if (priceWithoutComma.length > 10) {
       return;
     }
 

--- a/fe/src/hooks/usePrice.ts
+++ b/fe/src/hooks/usePrice.ts
@@ -10,11 +10,12 @@ type PriceInputReturnType = {
 export const usePrice = (initialPrice: string = ''): PriceInputReturnType => {
   const { value, onChangeValue, isValidValue, warningMessage } = useInput({
     initialValue: initialPrice,
-    validator: (value: string) => /^[0-9,]*$/.test(value),
+    validator: (value: string) => /^[0-9,]*$/.test(value), // 숫자와 쉼표(,)만 입력 가능
     warningMessage: '숫자와 쉼표(,)만 입력 가능합니다.',
   });
 
-  const priceValidator = (price: string) => /^[0-9]$/.test(price);
+  // 숫자만으로 이루어졌는지 확인하는 함수
+  const priceValidator = (price: string) => /^[0-9]*$/.test(price);
 
   const onChangePrice = (price: string) => {
     if (price === '') {

--- a/fe/src/mocks/data/images.ts
+++ b/fe/src/mocks/data/images.ts
@@ -1,0 +1,1 @@
+export const images:string[] = [];

--- a/fe/src/mocks/data/locations.ts
+++ b/fe/src/mocks/data/locations.ts
@@ -2,6 +2,10 @@ export const locationsWithQuery: LocationWithQueryDataFromServer = {
   success: true,
   data: [
     {
+      id: 1, //long
+      name: '서울 강남구 역삼1동',
+    },
+    {
       id: 3, //long
       name: '서울 강남구 개포1동',
     },

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -5,14 +5,17 @@ import { token, users } from './data/users';
 import { images } from './data/images';
 
 let locations: LocationType[] = [
-  { id: 1, name: '안양99동', isMainLocation: true },
-  { id: 2, name: '안양100동', isMainLocation: false },
+  { id: 1, name: '역삼1동', isMainLocation: true },
+  { id: 100, name: '안양100동', isMainLocation: false },
 ];
 
 export const handlers = [
   //내동네
   rest.get(`/api/users/locations`, (_, res, ctx) => {
-    return res(ctx.delay(300), ctx.status(200), ctx.json(locations));
+    return res(ctx.delay(300), ctx.status(200), ctx.json({
+      success: true,
+      data: locations,
+    }));
   }),
   // 내동네 삭제
   rest.delete(`/api/users/locations/:id`, (req, res, ctx) => {

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { rest } from 'msw';
 import { categoryList } from './data/categories';
 import { locationsWithQuery } from './data/locations';
 import { token, users } from './data/users';
+import { images } from './data/images';
 
 let locations: LocationType[] = [
   { id: 1, name: '안양99동', isMainLocation: true },
@@ -181,5 +182,25 @@ export const handlers = [
       ctx.status(200),
       ctx.json({ success: true, data: { accessToken: token } }),
     );
+  }),
+
+  rest.post('/api/images', async (req, res, ctx) => {
+    const body = await req.json();
+
+    if (!body?.image) {
+      return res(ctx.status(200), ctx.json({ success: false }));
+    }
+
+    images.push('https://picsum.photos/200');
+
+    const data = {
+      success: true,
+      data: {
+        imageId: images.length,
+        imageUrl: images[images.length - 1],
+      },
+    };
+
+    return res(ctx.status(200), ctx.json(data));
   }),
 ];

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { rest } from 'msw';
+import { DefaultRequestMultipartBody, rest } from 'msw';
 import { categoryList } from './data/categories';
 import { images } from './data/images';
 import { locationsWithQuery } from './data/locations';
@@ -192,20 +192,30 @@ export const handlers = [
   }),
 
   rest.post('/api/images', async (req, res, ctx) => {
-    const body = await req.json();
-
-    if (!body?.image) {
+    if (!req.body) {
       return res(ctx.status(200), ctx.json({ success: false }));
     }
 
-    images.push('https://picsum.photos/200');
+    const body = req.body as DefaultRequestMultipartBody;
+    const reqImages = body.images;
+
+    if (!reqImages) {
+      return res(ctx.status(200), ctx.json({ success: false }));
+    }
+
+    const newImages = [];
+    for (let i = 0; i < reqImages.length; i++) {
+      newImages.push('https://picsum.photos/200');
+    }
+
+    images.push(...newImages);
 
     const data = {
       success: true,
-      data: {
-        imageId: images.length,
-        imageUrl: images[images.length - 1],
-      },
+      data: newImages.map((image, index) => ({
+        imageId: images.length + index + 1,
+        imageUrl: image,
+      })),
     };
 
     return res(ctx.status(200), ctx.json(data));

--- a/fe/src/mocks/handlers.ts
+++ b/fe/src/mocks/handlers.ts
@@ -1,8 +1,8 @@
 import { rest } from 'msw';
 import { categoryList } from './data/categories';
+import { images } from './data/images';
 import { locationsWithQuery } from './data/locations';
 import { token, users } from './data/users';
-import { images } from './data/images';
 
 let locations: LocationType[] = [
   { id: 1, name: '역삼1동', isMainLocation: true },
@@ -12,10 +12,14 @@ let locations: LocationType[] = [
 export const handlers = [
   //내동네
   rest.get(`/api/users/locations`, (_, res, ctx) => {
-    return res(ctx.delay(300), ctx.status(200), ctx.json({
-      success: true,
-      data: locations,
-    }));
+    return res(
+      ctx.delay(300),
+      ctx.status(200),
+      ctx.json({
+        success: true,
+        data: locations,
+      }),
+    );
   }),
   // 내동네 삭제
   rest.delete(`/api/users/locations/:id`, (req, res, ctx) => {
@@ -205,5 +209,23 @@ export const handlers = [
     };
 
     return res(ctx.status(200), ctx.json(data));
+  }),
+
+  rest.post('/api/products', async (req, res, ctx) => {
+    const body = await req.json();
+
+    if (
+      !body?.images ||
+      !body?.name ||
+      !body?.categoryId ||
+      !body?.locationId
+    ) {
+      return res(ctx.status(200), ctx.json({ success: false }));
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({ success: true, data: { productId: 1 } }),
+    );
   }),
 ];

--- a/fe/src/pages/Home.tsx
+++ b/fe/src/pages/Home.tsx
@@ -23,8 +23,11 @@ import { modifiedLocaitionName } from '@utils/modifyLocationName';
 import { useLayoutStore } from '@/stores/layoutStore';
 import { usePopupStore } from '@/stores/popupStore';
 import { useMyLocations } from '@/queries/location';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@/constants/path';
 
 export const Home: React.FC = () => {
+  const navigate = useNavigate();
   const { isLogin } = useAuth();
   const { serverLocations } = useMyLocations(isLogin);
 
@@ -165,7 +168,7 @@ export const Home: React.FC = () => {
               </Button>
             </RightButton>
           </TopBar>
-          <Button variant="fab" size="l" className="button__add">
+          <Button variant="fab" size="l" className="button__add" onClick={() => navigate(PATH.newProduct)}>
             <Plus />
           </Button>
           <ListBox>

--- a/fe/src/pages/NewProduct.tsx
+++ b/fe/src/pages/NewProduct.tsx
@@ -18,8 +18,15 @@ import { Theme, css } from '@emotion/react';
 import { useState } from 'react';
 
 export const NewProduct: React.FC = () => {
-  const { value: title, onChangeValue: onChangeTitle } = useInput({
+  const [imageList, setImageList] = useState<ImageType[]>([]);
+  const {
+    value: title,
+    onChangeValue: onChangeTitle,
+    isValidValue: isValidTitle,
+  } = useInput({
     initialValue: '빈티지 롤러 스케이트',
+    validator: (value) => value.length > 0,
+    warningMessage: '제목을 입력해주세요',
   });
   const { selectedCategory, categories, selectCategory } = useCategorySelector({
     initialCategoryName: '가구/인테리어',
@@ -38,6 +45,12 @@ export const NewProduct: React.FC = () => {
     },
   });
 
+  const isRequiredFieldsFilled =
+    imageList.length !== 0 &&
+    isValidTitle &&
+    selectedCategory &&
+    selectedLocation;
+
   return (
     <>
       <TopBar>
@@ -48,14 +61,24 @@ export const NewProduct: React.FC = () => {
           </Button>
         </LeftButton>
         <RightButton>
-          <Button variant="text">
-            <span className="control-btn">다음</span>
+          <Button variant="text" disabled={!isRequiredFieldsFilled}>
+            <span className="control-btn">확인</span>
           </Button>
         </RightButton>
       </TopBar>
       <div css={(theme) => pageStyle(theme)}>
         <div className="image-input">
-          <ImageInput />
+          <ImageInput
+            imageList={imageList}
+            onAddImage={(image: ImageType) =>
+              setImageList((i) => [...i, image])
+            }
+            onDeleteImage={(image: ImageType) =>
+              setImageList((i) =>
+                i.filter((img) => img.imageId !== image.imageId),
+              )
+            }
+          />
         </div>
         <div className="title-input">
           <Input

--- a/fe/src/pages/NewProduct.tsx
+++ b/fe/src/pages/NewProduct.tsx
@@ -14,6 +14,7 @@ import { useCategorySelector } from '@/hooks/useCategorySelector';
 import { useInput } from '@/hooks/useInput';
 import { usePrice } from '@/hooks/usePrice';
 import { Theme, css } from '@emotion/react';
+import { useState } from 'react';
 
 export const NewProduct: React.FC = () => {
   const { value: title, onChangeValue: onChangeTitle } = useInput({
@@ -22,16 +23,13 @@ export const NewProduct: React.FC = () => {
   const { selectedCategory, categories, selectCategory } = useCategorySelector(
     {},
   );
-  const {
-    price, 
-    onChangePrice,
-    priceWarningMessage,
-  } = usePrice('169,000');
-  const content = `어린시절 추억의 향수를 불러 일으키는 롤러 스케이트입니다. 빈티지 특성상 사용감 있지만 전체적으로 깨끗한 상태입니다.
+  const { price, onChangePrice, priceWarningMessage } = usePrice('169,000');
+  const [description, setDescription] =
+    useState(`어린시절 추억의 향수를 불러 일으키는 롤러 스케이트입니다. 빈티지 특성상 사용감 있지만 전체적으로 깨끗한 상태입니다.
 
   촬영용 소품이나, 거실에 장식용으로 추천해 드립니다. 단품 입고 되었습니다. 새 제품으로 보존된 제품으로 전용박스까지 보내드립니다.
   
-  사이즈는 235 입니다.`;
+  사이즈는 235 입니다.`);
 
   return (
     <>
@@ -79,8 +77,9 @@ export const NewProduct: React.FC = () => {
         </div>
         <div className="content-input">
           <TextArea
-            value={content}
-            onChange={() => {}}
+            value={description}
+            minRows={5}
+            onChange={(value: string) => setDescription(value)}
             placeholder="역삼 1동에 올릴 게시물 내용을 작성해주세요.(판매금지 물품은 게시가 제한될 수 있어요.)"
           />
         </div>

--- a/fe/src/pages/NewProduct.tsx
+++ b/fe/src/pages/NewProduct.tsx
@@ -80,7 +80,7 @@ export const NewProduct: React.FC = () => {
       <TopBar>
         <Title>내 물건 팔기</Title>
         <LeftButton>
-          <Button variant="text">
+          <Button variant="text" onClick={() => navigate(-1)}>
             <span className="control-btn">닫기</span>
           </Button>
         </LeftButton>

--- a/fe/src/pages/NewProduct.tsx
+++ b/fe/src/pages/NewProduct.tsx
@@ -32,7 +32,10 @@ export const NewProduct: React.FC = () => {
   
   사이즈는 235 입니다.`);
   const { selectedLocation, selectLocation, locations } = useLocationSelector({
-    initialLocation: { id: 1, name: '역삼 1동'}
+    initialLocation: {
+      id: 12,
+      name: '서울 강남구 개포8동',
+    },
   });
 
   return (

--- a/fe/src/pages/NewProduct.tsx
+++ b/fe/src/pages/NewProduct.tsx
@@ -1,6 +1,6 @@
 import { EditBar } from '@/components/common/actionBar/EditBar';
 import { Button } from '@/components/common/button/Button';
-import { ChevronRight, MapPinFilled } from '@/components/common/icons';
+import { MapPinFilled } from '@/components/common/icons';
 import { Input } from '@/components/common/input/Input';
 import { TextArea } from '@/components/common/input/TextArea';
 import { CategoryModal } from '@/components/common/modal/categoryModal/CategoryModal';
@@ -8,25 +8,25 @@ import { LeftButton } from '@/components/common/topBar/LeftButton';
 import { RightButton } from '@/components/common/topBar/RightButton';
 import { Title } from '@/components/common/topBar/Title';
 import { TopBar } from '@/components/common/topBar/TopBar';
+import { CategorySelector } from '@/components/new/CategorySelector';
 import { ImageInput } from '@/components/new/ImageInput';
-import { usePopupStore } from '@/stores/popupStore';
+import { useCategorySelector } from '@/hooks/useCategorySelector';
+import { useInput } from '@/hooks/useInput';
 import { Theme, css } from '@emotion/react';
 
 export const NewProduct: React.FC = () => {
-  const { togglePopup, setCurrentDim } = usePopupStore();
-
-  const title = '빈티지 롤러 스케이트';
+  const { value: title, onChangeValue: onChangeTitle } = useInput({
+    initialValue: '빈티지 롤러 스케이트',
+  });
+  const { selectedCategory, categories, selectCategory } = useCategorySelector(
+    {},
+  );
   const price = '169,000';
   const content = `어린시절 추억의 향수를 불러 일으키는 롤러 스케이트입니다. 빈티지 특성상 사용감 있지만 전체적으로 깨끗한 상태입니다.
 
   촬영용 소품이나, 거실에 장식용으로 추천해 드립니다. 단품 입고 되었습니다. 새 제품으로 보존된 제품으로 전용박스까지 보내드립니다.
   
   사이즈는 235 입니다.`;
-
-  const openCategoryModal = () => {
-    togglePopup('modal', true);
-    setCurrentDim('modal');
-  };
 
   return (
     <>
@@ -52,27 +52,15 @@ export const NewProduct: React.FC = () => {
             variant="ghost"
             value={title}
             placeholder="내용을 입력하세요"
+            onChange={onChangeTitle}
           />
-          <div className="title-input__categories">
-            <div className="title-input__categories--container">
-              <Button variant="category" state="active">
-                기타중고물품
-              </Button>
-              <Button variant="category" state="default">
-                여성용품
-              </Button>
-              <Button variant="category" state="default">
-                여성잡화
-              </Button>
-            </div>
-            <Button
-              variant="text"
-              className="title-input__categories--more-btn"
-              onClick={openCategoryModal}
-            >
-              <ChevronRight />
-            </Button>
-          </div>
+          {(title || selectedCategory) && (
+            <CategorySelector
+              categories={categories}
+              selectedCategory={selectedCategory}
+              onSelectCategory={selectCategory}
+            />
+          )}
         </div>
         <div className="price-input">
           <Input
@@ -89,7 +77,10 @@ export const NewProduct: React.FC = () => {
             placeholder="역삼 1동에 올릴 게시물 내용을 작성해주세요.(판매금지 물품은 게시가 제한될 수 있어요.)"
           />
         </div>
-        <CategoryModal />
+        <CategoryModal
+          categoryList={categories}
+          onSelectCategory={selectCategory}
+        />
       </div>
       <EditBar>
         <Button variant="text">
@@ -115,20 +106,5 @@ const pageStyle = (theme: Theme) => css`
     flex-direction: column;
     padding-bottom: 16px;
     border-bottom: 0.8px solid ${theme.color.neutral.border};
-  }
-
-  & .title-input__categories {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-
-    &--container {
-      display: flex;
-      gap: 4px;
-    }
-
-    &--more-btn > svg {
-      stroke: ${theme.color.neutral.textStrong};
-    }
   }
 `;

--- a/fe/src/pages/NewProduct.tsx
+++ b/fe/src/pages/NewProduct.tsx
@@ -12,6 +12,7 @@ import { CategorySelector } from '@/components/new/CategorySelector';
 import { ImageInput } from '@/components/new/ImageInput';
 import { useCategorySelector } from '@/hooks/useCategorySelector';
 import { useInput } from '@/hooks/useInput';
+import { usePrice } from '@/hooks/usePrice';
 import { Theme, css } from '@emotion/react';
 
 export const NewProduct: React.FC = () => {
@@ -21,7 +22,11 @@ export const NewProduct: React.FC = () => {
   const { selectedCategory, categories, selectCategory } = useCategorySelector(
     {},
   );
-  const price = '169,000';
+  const {
+    price, 
+    onChangePrice,
+    priceWarningMessage,
+  } = usePrice('169,000');
   const content = `어린시절 추억의 향수를 불러 일으키는 롤러 스케이트입니다. 빈티지 특성상 사용감 있지만 전체적으로 깨끗한 상태입니다.
 
   촬영용 소품이나, 거실에 장식용으로 추천해 드립니다. 단품 입고 되었습니다. 새 제품으로 보존된 제품으로 전용박스까지 보내드립니다.
@@ -68,6 +73,8 @@ export const NewProduct: React.FC = () => {
             label="₩"
             value={price}
             placeholder="가격을 입력하세요"
+            onChange={onChangePrice}
+            warningMessage={priceWarningMessage}
           />
         </div>
         <div className="content-input">

--- a/fe/src/pages/NewProduct.tsx
+++ b/fe/src/pages/NewProduct.tsx
@@ -1,7 +1,6 @@
 import { EditBar } from '@/components/common/actionBar/EditBar';
 import { Button } from '@/components/common/button/Button';
-import { Camera, ChevronRight, MapPinFilled } from '@/components/common/icons';
-import { PictureItem } from '@/components/common/imageBox/PictureItem';
+import { ChevronRight, MapPinFilled } from '@/components/common/icons';
 import { Input } from '@/components/common/input/Input';
 import { TextArea } from '@/components/common/input/TextArea';
 import { CategoryModal } from '@/components/common/modal/categoryModal/CategoryModal';
@@ -9,14 +8,13 @@ import { LeftButton } from '@/components/common/topBar/LeftButton';
 import { RightButton } from '@/components/common/topBar/RightButton';
 import { Title } from '@/components/common/topBar/Title';
 import { TopBar } from '@/components/common/topBar/TopBar';
+import { ImageInput } from '@/components/new/ImageInput';
 import { usePopupStore } from '@/stores/popupStore';
 import { Theme, css } from '@emotion/react';
 
 export const NewProduct: React.FC = () => {
   const { togglePopup, setCurrentDim } = usePopupStore();
 
-  const randomGitProfile =
-    'https://avatars.githubusercontent.com/u/48426991?v=4';
   const title = '빈티지 롤러 스케이트';
   const price = '169,000';
   const content = `어린시절 추억의 향수를 불러 일으키는 롤러 스케이트입니다. 빈티지 특성상 사용감 있지만 전체적으로 깨끗한 상태입니다.
@@ -47,21 +45,7 @@ export const NewProduct: React.FC = () => {
       </TopBar>
       <div css={(theme) => pageStyle(theme)}>
         <div className="image-input">
-          <div className="image-input__container">
-            <button className="image-input__add-btn">
-              <Camera />
-              <span>0/10</span>
-            </button>
-            <PictureItem
-              size="m"
-              imageUrl={randomGitProfile}
-              label="대표 사진"
-            />
-            <PictureItem size="m" imageUrl={randomGitProfile} />
-            <PictureItem size="m" imageUrl={randomGitProfile} />
-            <PictureItem size="m" imageUrl={randomGitProfile} />
-            <PictureItem size="m" imageUrl={randomGitProfile} />
-          </div>
+          <ImageInput />
         </div>
         <div className="title-input">
           <Input
@@ -131,39 +115,6 @@ const pageStyle = (theme: Theme) => css`
     flex-direction: column;
     padding-bottom: 16px;
     border-bottom: 0.8px solid ${theme.color.neutral.border};
-  }
-
-  & .image-input {
-    padding-top: 8px;
-    overflow-x: auto;
-    scroll-behavior: smooth;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-
-    &__container {
-      display: flex;
-      gap: 16px;
-    }
-
-    &__add-btn {
-      flex-shrink: 0;
-      width: 80px;
-      height: 80px;
-      padding: 16px;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      gap: 4px;
-      border-radius: 16px;
-      border: 0.8px solid ${theme.color.neutral.border};
-
-      & > svg {
-        stroke: ${theme.color.neutral.textStrong};
-      }
-    }
   }
 
   & .title-input__categories {

--- a/fe/src/pages/NewProduct.tsx
+++ b/fe/src/pages/NewProduct.tsx
@@ -1,6 +1,5 @@
 import { EditBar } from '@/components/common/actionBar/EditBar';
 import { Button } from '@/components/common/button/Button';
-import { MapPinFilled } from '@/components/common/icons';
 import { Input } from '@/components/common/input/Input';
 import { TextArea } from '@/components/common/input/TextArea';
 import { CategoryModal } from '@/components/common/modal/categoryModal/CategoryModal';
@@ -10,8 +9,10 @@ import { Title } from '@/components/common/topBar/Title';
 import { TopBar } from '@/components/common/topBar/TopBar';
 import { CategorySelector } from '@/components/new/CategorySelector';
 import { ImageInput } from '@/components/new/ImageInput';
+import { LocationSelector } from '@/components/new/LocationSelector';
 import { useCategorySelector } from '@/hooks/useCategorySelector';
 import { useInput } from '@/hooks/useInput';
+import { useLocationSelector } from '@/hooks/useLocationSelector';
 import { usePrice } from '@/hooks/usePrice';
 import { Theme, css } from '@emotion/react';
 import { useState } from 'react';
@@ -20,9 +21,9 @@ export const NewProduct: React.FC = () => {
   const { value: title, onChangeValue: onChangeTitle } = useInput({
     initialValue: '빈티지 롤러 스케이트',
   });
-  const { selectedCategory, categories, selectCategory } = useCategorySelector(
-    {},
-  );
+  const { selectedCategory, categories, selectCategory } = useCategorySelector({
+    initialCategoryName: '가구/인테리어',
+  });
   const { price, onChangePrice, priceWarningMessage } = usePrice('169,000');
   const [description, setDescription] =
     useState(`어린시절 추억의 향수를 불러 일으키는 롤러 스케이트입니다. 빈티지 특성상 사용감 있지만 전체적으로 깨끗한 상태입니다.
@@ -30,6 +31,9 @@ export const NewProduct: React.FC = () => {
   촬영용 소품이나, 거실에 장식용으로 추천해 드립니다. 단품 입고 되었습니다. 새 제품으로 보존된 제품으로 전용박스까지 보내드립니다.
   
   사이즈는 235 입니다.`);
+  const { selectedLocation, selectLocation, locations } = useLocationSelector({
+    initialLocation: { id: 1, name: '역삼 1동'}
+  });
 
   return (
     <>
@@ -89,10 +93,11 @@ export const NewProduct: React.FC = () => {
         />
       </div>
       <EditBar>
-        <Button variant="text">
-          <MapPinFilled fill="#000" />
-          역삼1동
-        </Button>
+        <LocationSelector
+          selectedLocation={selectedLocation}
+          locations={locations}
+          onSelectLocation={selectLocation}
+        />
       </EditBar>
     </>
   );

--- a/fe/src/pages/Signup.tsx
+++ b/fe/src/pages/Signup.tsx
@@ -1,6 +1,7 @@
 import { useNickname } from '@/hooks/useNickname';
 import { useSignup } from '@/queries/auth';
 import { useAuthStore } from '@/stores/authStore';
+import { useRegisteredLocationsStore } from '@/stores/locationStore';
 import { usePopupStore } from '@/stores/popupStore';
 import { setLoginInfo } from '@/utils/localStorage';
 import { ReactComponent as Check } from '@assets/check.svg';
@@ -15,12 +16,10 @@ import { TopBar } from '@components/common/topBar/TopBar';
 import { PATH } from '@constants/path';
 
 import { Theme, css } from '@emotion/react';
-import { useLocationControl } from '@hooks/useLocationControl';
 import { Navigate, useNavigate } from 'react-router-dom';
 
 export const Signup: React.FC = () => {
   const navigate = useNavigate();
-
 
   const {
     nickname,
@@ -34,12 +33,13 @@ export const Signup: React.FC = () => {
       /^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]{2,10}$/.test(nickname),
     defaultWarning: '2~10글자 닉네임을 입력하세요',
   });
-  const { locations } = useLocationControl();
+  const { localLocations } = useRegisteredLocationsStore();
   const { togglePopup, setCurrentDim } = usePopupStore();
   const { signUpInProgress } = useAuthStore();
   const signupMutation = useSignup();
 
-  const submitEnabled = isUniqueNickname && locations && locations.length > 0;
+  const submitEnabled =
+    isUniqueNickname && localLocations && localLocations.length > 0;
 
   const goToAuth = () => {
     navigate(PATH.account, { replace: true });

--- a/fe/src/queries/products.ts
+++ b/fe/src/queries/products.ts
@@ -1,7 +1,7 @@
-import { getProducts } from '@api/api';
+import { getProducts, requestImageUpload } from '@api/api';
 import { QUERY_KEY } from '@constants/queryKey';
 import { useMemo } from 'react';
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery, useMutation } from 'react-query';
 
 export const useProducts = (
   locationId: number | null,
@@ -42,3 +42,9 @@ export const useProducts = (
     refetch,
   };
 };
+
+export const useImageUpload = () => {
+  return useMutation<ImageDataFromServer, unknown, FormData>({
+    mutationFn: (image: FormData) => requestImageUpload(image),
+  })
+}

--- a/fe/src/queries/products.ts
+++ b/fe/src/queries/products.ts
@@ -1,4 +1,4 @@
-import { getProducts, requestImageUpload } from '@api/api';
+import { addNewProduct, getProducts, requestImageUpload } from '@api/api';
 import { QUERY_KEY } from '@constants/queryKey';
 import { useMemo } from 'react';
 import { useInfiniteQuery, useMutation } from 'react-query';
@@ -46,5 +46,12 @@ export const useProducts = (
 export const useImageUpload = () => {
   return useMutation<ImageDataFromServer, unknown, FormData>({
     mutationFn: (image: FormData) => requestImageUpload(image),
-  })
-}
+  });
+};
+
+export const useProductAddition = () => {
+  return useMutation<ProductAdditionResponse, unknown, ProductFormData>({
+    mutationFn: (productFormData: ProductFormData) =>
+      addNewProduct(productFormData),
+  });
+};

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -13,6 +13,7 @@ import { OauthLoading } from './pages/OauthLoading';
 import { Sales } from './pages/Sales';
 import { Signup } from './pages/Signup';
 import { useTokenRefresh } from './queries/auth';
+import { ProductDetail } from './pages/ProductDetail';
 
 export const AppRoutes: React.FC = () => {
   useTokenRefresh();

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -14,7 +14,6 @@ import { ProductDetail } from './pages/ProductDetail';
 import { Sales } from './pages/Sales';
 import { Signup } from './pages/Signup';
 import { useTokenRefresh } from './queries/auth';
-import { ProductDetail } from './pages/ProductDetail';
 
 export const AppRoutes: React.FC = () => {
   useTokenRefresh();

--- a/fe/src/types/type.d.ts
+++ b/fe/src/types/type.d.ts
@@ -100,7 +100,7 @@ type LoginDataFromServer = {
 type ImageType = {
   imageId: number;
   imageUrl: string;
-}
+};
 
 type ImageDataFromServer =
   | {
@@ -110,3 +110,19 @@ type ImageDataFromServer =
   | {
       success: false;
     };
+
+type ProductFormData = {
+  images: number[];
+  name: string;
+  categoryId: number;
+  locationId: number;
+  content?: string;
+  price?: number;
+};
+
+type ProductAdditionResponse = {
+  success: boolean;
+  data?: {
+    productId: number;
+  };
+}

--- a/fe/src/types/type.d.ts
+++ b/fe/src/types/type.d.ts
@@ -97,13 +97,15 @@ type LoginDataFromServer = {
       };
 };
 
+type ImageData = {
+  imageId: number;
+  imageUrl: string;
+}
+
 type ImageDataFromServer =
   | {
       success: true;
-      data: {
-        imageId: number;
-        imageUrl: string;
-      };
+      data: ImageData;
     }
   | {
       success: false;

--- a/fe/src/types/type.d.ts
+++ b/fe/src/types/type.d.ts
@@ -105,7 +105,7 @@ type ImageType = {
 type ImageDataFromServer =
   | {
       success: true;
-      data: ImageType;
+      data: ImageType[];
     }
   | {
       success: false;

--- a/fe/src/types/type.d.ts
+++ b/fe/src/types/type.d.ts
@@ -96,3 +96,15 @@ type LoginDataFromServer = {
         accessToken: string;
       };
 };
+
+type ImageDataFromServer =
+  | {
+      success: true;
+      data: {
+        imageId: number;
+        imageUrl: string;
+      };
+    }
+  | {
+      success: false;
+    };

--- a/fe/src/types/type.d.ts
+++ b/fe/src/types/type.d.ts
@@ -97,7 +97,7 @@ type LoginDataFromServer = {
       };
 };
 
-type ImageData = {
+type ImageType = {
   imageId: number;
   imageUrl: string;
 }
@@ -105,7 +105,7 @@ type ImageData = {
 type ImageDataFromServer =
   | {
       success: true;
-      data: ImageData;
+      data: ImageType;
     }
   | {
       success: false;

--- a/fe/src/utils/formatPrice.ts
+++ b/fe/src/utils/formatPrice.ts
@@ -11,3 +11,11 @@ export const formatPrice = (price: number) => {
 
   return `${price.toLocaleString('ko-KR')}원`;
 };
+
+export const commaStringToNumber = (price: string): number => {
+  return Number(price.replace(/,/g, ''));
+};
+
+export const numberToCommaString = (price: number) => {
+  return price.toLocaleString('ko-KR');
+};

--- a/fe/src/utils/getRandomElementsFromArray.ts
+++ b/fe/src/utils/getRandomElementsFromArray.ts
@@ -1,0 +1,18 @@
+type PickOptions<T> = {
+  array: T[];
+  count: number;
+};
+
+export const getRandomElementsFromArray = <T>(options: PickOptions<T>): T[] => {
+  const { array, count } = options;
+  const copyArray = [...array];
+  const pickedArray = [];
+
+  for (let i = 0; i < count; i++) {
+    const randomIndex = Math.floor(Math.random() * copyArray.length);
+    pickedArray.push(copyArray[randomIndex]);
+    copyArray.splice(randomIndex, 1);
+  }
+
+  return pickedArray;
+};


### PR DESCRIPTION
## What is this PR? 👓

상품 등록 페이지 기능을 구현했습니다.

## Key changes 🔑

### 컴포넌트
- ImageInput
  - 이미지 업로드를 위한 버튼 & 업로드된 이미지를 표시
  - 사용처에서 이미지 배열과 추가, 삭제시 호출할 함수를 전달받습니다.
- CategorySelector
  - 전체 카테고리 목록, 선택된 카테고리로 랜덤한 카테고리 3래를 뽑습니다.
  - 뽑힌 카테고리 3개 중 하나를 선택하면 다시 뽑지 않습니다.
  - `>` 버튼을 클릭하면 전체 카테고리 목록을 보여주는 모달이 열립니다. 모달에서 카테고리를 선택했을 때 뽑힌 3개 중 없는 것이면 추가하고 기존의 뽑힌 것 중 마지막 카테고리를 없앱니다. 즉, 뽑힌 카테고리는 3개로 유지됩니다.
- LocationSelector
  - 핀 아이콘 + 선택된 위치 정보를 가진 버튼
  - 버튼을 누르면 작성자의 동네 목록이 아래에서 애니메이션과 함께 등장합니다.
  - 동네 버튼을 누르거나 [X]버튼을 누르면 동네 목록이 애니메이션과 함께 사라집니다.
- TextArea
  - 내용의 길이에 따라 높이가 늘어나는 textarea
  - minRows로 최소 높이를 설정할 수 있다. 전달하지 않으면 최소 높이는 1.
 
### 커스텀 훅
- useCategorySelector
  - CategorySelector 에서 사용할 상태를 받아오기 위한 커스텀 훅입니다.
  - 초기 카테고리 이름을 전달받습니다. (상품 수정 기능을 위한 확장 고려)
  - 카테고리 모달에서 mock을 사용하고 있길래, 여기서 전체 카테고리 목록을 반환해서 함께 사용했습니다.
  - 카테고리 목록과 선택된 카테고리, 카테고리 선택 이벤트 핸들러를 반환합니다.
- useCategoryExample
  - CategorySelector에서 3개의 예시 카테고리를 뽑기 위한 커스텀 훅입니다.
-  useInput
  - 초기값, 평가 함수, 경고문을 전달받고 입력값, 값 변경 핸들러, 유효성 검사 결과, 경고문을 반환 합니다.
  - 제네릭을 사용해 초기값으로 전달한 타입에 따라 타입이 결정됩니다.
- usePrice
  - useInput을 사용해서 가격의 값, 유효성 검사 결과, 경고문, 값 변경 핸들러를 반환합니다.
  - 숫자만 입력하면 1000 단위마다 콤마(,)를 추가합니다.

## To reviewers 👋

- 푸반이 미리 만들어두신 ImageBox, CategoryModal 등을 활용해서 편하게 구현할 수 있었습니다. 감사합니다 🙏 
- 수정까지 확장을 의식하긴 했지만, 구조가 복잡해서 나중에 상세 페이지와의 연결 때 논의를 해봐야할 것 같습니다.