### PR TITLE
routes 구조 변경

### DIFF
--- a/fe/src/components/common/navBar/NavBar.tsx
+++ b/fe/src/components/common/navBar/NavBar.tsx
@@ -1,16 +1,18 @@
-import { PATH } from '@constants/path';
 import {
   Heart,
   Home,
-  MessageNoti,
   Message,
+  MessageNoti,
   News,
   UserCircle,
 } from '@components/common/icons';
+import { PATH } from '@constants/path';
 import { Theme, css } from '@emotion/react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, matchRoutes, useLocation } from 'react-router-dom';
 
 export const NavBar: React.FC = () => {
+  const currentLocation = useLocation();
+
   const isMessageNoti = false; //TODO 추후 교체합니다
 
   const messageTabIcon = isMessageNoti ? <MessageNoti /> : <Message />;
@@ -43,16 +45,21 @@ export const NavBar: React.FC = () => {
     },
   ];
 
+  const matchedAllowedRoutes = matchRoutes(tabs, currentLocation) ?? [];
+  const isAllowedRoute = matchedAllowedRoutes.length > 0;
+
   return (
     <>
-      <nav css={(theme) => navStyle(theme)}>
-        {tabs.map((tab) => (
-          <NavLink key={tab.path} to={tab.path} className="tab">
-            {tab.icon}
-            {tab.label}
-          </NavLink>
-        ))}
-      </nav>
+      {isAllowedRoute && (
+        <nav css={(theme) => navStyle(theme)}>
+          {tabs.map((tab) => (
+            <NavLink key={tab.path} to={tab.path} className="tab">
+              {tab.icon}
+              {tab.label}
+            </NavLink>
+          ))}
+        </nav>
+      )}
     </>
   );
 };

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -21,29 +21,24 @@ export const AppRoutes: React.FC = () => {
   return (
     <div css={globalStyle} id="app-layout">
       <Routes>
-        {/* TODO: 하단바 X - 카테고리 페이지 */}
-        {/* TODO: 하단바 X - 회원가입 페이지(리다이렉트) */}
-        {/* TODO: 하단바 O - 등록페이지 / 인증 필요 */}
-        {/* TODO: 하단바 O - 상세페이지 / 인증 필요*/}
-        {/* TODO: 하단바 O - 채팅페이지 / 인증 필요 */}
         <Route element={<Layout />}>
           <Route element={<OnlyLoginUserRoute />}>
             <Route path={PATH.sales} element={<Sales />} />
             <Route path={PATH.interests} element={<Interests />} />
             <Route path={PATH.chat} element={<Chat />} />
+            <Route path={PATH.newProduct} element={<NewProduct />} />
+            <Route path={PATH.editProduct()} element={<NewProduct />} />
+          </Route>
+
+          <Route element={<OnlyNotLoginUserRoute />}>
+            <Route path={PATH.redirect} element={<OauthLoading />} />
+            <Route path={PATH.signup} element={<Signup />} />
           </Route>
 
           <Route path={PATH.home} element={<Home />} />
           <Route path={PATH.account} element={<Account />} />
           <Route path={PATH.notFound} element={<NotFound />} />
-        </Route>
-
-        <Route path={PATH.newProduct} element={<NewProduct />} />
-        <Route path={`${PATH.detail}/:id`} element={<ProductDetail />} />
-
-        <Route element={<OnlyNotLoginUserRoute />}>
-          <Route path={PATH.redirect} element={<OauthLoading />} />
-          <Route path={PATH.signup} element={<Signup />} />
+          <Route path={`${PATH.detail}/:id`} element={<ProductDetail />} />
         </Route>
       </Routes>
     </div>
@@ -52,12 +47,22 @@ export const AppRoutes: React.FC = () => {
 
 const OnlyLoginUserRoute: React.FC = () => {
   const { isLogin } = useAuth();
-  return isLogin ? <Outlet /> : <Navigate to={PATH.account} />;
+
+  return isLogin ? (
+    <Outlet />
+  ) : (
+    <Navigate to={PATH.invalidAccess} replace={true} />
+  );
 };
 
 const OnlyNotLoginUserRoute: React.FC = () => {
   const { isLogin } = useAuth();
-  return isLogin ? <Navigate to={PATH.home} /> : <Outlet />;
+
+  return isLogin ? (
+    <Navigate to={PATH.invalidAccess} replace={true} />
+  ) : (
+    <Outlet />
+  );
 };
 
 const globalStyle = css`


### PR DESCRIPTION
## What is this PR? 👓

Protected route와 layout route 중복을 줄이고 직관적으로 이해하기 쉬운 구조로 변경했습니다.
이제 모든 경로는 Layout 안에서 렌더링 됩니다.

## Key changes 🔑

- routes
  - Layout Route 안에 모든 경로가 들어갑니다.
- NavBar
  - 현재 URL과 허용되는 경로를 비교해서 조건부 렌더링 되도록 변경했습니다.

## To reviewers 👋

- Layout은 페이지의 레이아웃을 정의하는 역할을 맡은 컴포넌트라고 생각해서 경로에 대한 로직을 NavBar로 보냈습니다. 이상하다, 납득이 안 된다고 생각되시면 언제든 말씀해주세요 😉 
- NavBar 렌더링 조건을 위해 matchRoutes라는 react router dom 함수를 사용했습니다.
- 네비게이션 바가 필요한 경로는 따로 정의하지 않고 NavBar의 tabs를 사용했습니다.