### PR TITLE
채팅방 목록 페이지 UI

### DIFF
--- a/fe/src/components/common/chat/ChatItem.tsx
+++ b/fe/src/components/common/chat/ChatItem.tsx
@@ -1,0 +1,170 @@
+import { CountBadge } from '@components/common/countBadge/CountBadge';
+import { ImageBox } from '@components/common/imageBox/ImageBox';
+import { css, keyframes, Theme } from '@emotion/react';
+
+export type ChatItemProps = {
+  chatPartner: UserType;
+  lastMessage: string;
+  updatedAt: Date;
+  unreadMessages: number;
+  thumbnailUrl: string;
+};
+
+export const ChatItem: React.FC<ChatItemProps> = ({
+  chatPartner,
+  lastMessage,
+  updatedAt,
+  unreadMessages,
+  thumbnailUrl,
+}) => {
+  return (
+    <li css={(theme) => chatItemStyle(theme)}>
+      <ImageBox size="s" imageUrl={chatPartner.imageUrl} variant="circle" />
+      <div className="info">
+        <div className="info__title">
+          <span className="info__title--nickname">{chatPartner.nickname}</span>
+          <span className="info__title--time">
+            {updatedAt.toLocaleDateString()}
+          </span>
+        </div>
+        <div className="info__message">
+          <p>{lastMessage}</p>
+        </div>
+      </div>
+      <div className="unread-messages">
+        <CountBadge count={unreadMessages} />
+      </div>
+      <ImageBox size="s" imageUrl={thumbnailUrl} />
+    </li>
+  );
+};
+
+const chatItemStyle = (theme: Theme) => css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  border-bottom: 0.8px solid ${theme.color.neutral.border};
+
+  .info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    &__title {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+
+      &--nickname {
+        font: ${theme.font.displayStrong16};
+        color: ${theme.color.neutral.textStrong};
+      }
+
+      &--time {
+        font: ${theme.font.displayDefault12};
+        color: ${theme.color.neutral.textWeak};
+      }
+    }
+
+    &__message {
+      font: ${theme.font.displayDefault12};
+      color: ${theme.color.neutral.text};
+
+      & > p {
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+    }
+  }
+
+  .unread-messages {
+    align-self: stretch;
+    display: flex;
+    align-items: flex-start;
+  }
+`;
+
+export const SkeletonChatItem: React.FC = () => {
+  return (
+    <li css={(theme) => skeletonChatItemStyle(theme)}>
+      <ImageBox size="s" variant="circle" />
+      <div className="info">
+        <div className="info__title">
+          <div className="info__title--nickname"></div>
+          <div className="info__title--time"></div>
+        </div>
+        <div className="info__message"></div>
+      </div>
+      <div className="unread-messages">
+        <CountBadge count={0} />
+      </div>
+      <ImageBox size="s" />
+    </li>
+  );
+};
+
+const skeletonChatItemStyle = (theme: Theme) => css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  border-bottom: 0.8px solid ${theme.color.neutral.border};
+
+  & > * {
+    animation: ${fadeInOut} 1.5s ease-in-out 0.5s infinite;
+  }
+
+  .info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    &__title {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+
+      &--nickname {
+        width: 50px;
+        height: 24px;
+        border-radius: 4px;
+        background-color: ${theme.color.neutral.backgroundBold};
+      }
+
+      &--time {
+        width: 70px;
+        height: 24px;
+        border-radius: 4px;
+        background-color: ${theme.color.neutral.backgroundBold};
+      }
+    }
+
+    &__message {
+      height: 16px;
+      background-color: ${theme.color.neutral.backgroundBold};
+    }
+  }
+
+  .unread-messages {
+    align-self: stretch;
+    display: flex;
+    align-items: flex-start;
+  }
+`;
+
+const fadeInOut = keyframes`
+0% {
+  opacity: 1;
+}
+50% {
+  opacity: 0.4;
+}
+100% {
+  opacity: 1;
+}
+`;

--- a/fe/src/components/common/countBadge/CountBadge.tsx
+++ b/fe/src/components/common/countBadge/CountBadge.tsx
@@ -1,0 +1,25 @@
+import { css, Theme } from '@emotion/react';
+
+type Props = {
+  count: number;
+};
+
+export const CountBadge: React.FC<Props> = ({ count }) => {
+  return (
+    <div css={(theme) => countBadgeStyle(theme)}>
+      <span>{count}</span>
+    </div>
+  );
+};
+
+const countBadgeStyle = (theme: Theme) => css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  font: ${theme.font.displayDefault12};
+  color: ${theme.color.neutral.background};
+  background-color: ${theme.color.accent.backgroundPrimary};
+  border-radius: 50%;
+`;

--- a/fe/src/components/common/imageBox/ImageBox.tsx
+++ b/fe/src/components/common/imageBox/ImageBox.tsx
@@ -40,6 +40,7 @@ const imageBoxStyle = (
 
   return css`
     box-sizing: border-box;
+    flex-shrink: 0;
     ${SIZE_STYLES[size]}
     border:  ${imageUrl && `1px solid ${theme.color.neutral.border}`};
     background: ${imageUrl && `url('${imageUrl}')`}

--- a/fe/src/pages/Chat.tsx
+++ b/fe/src/pages/Chat.tsx
@@ -1,14 +1,88 @@
+import { ChatItem, ChatItemProps, SkeletonChatItem } from '@components/common/chat/ChatItem';
 import { Title } from '@components/common/topBar/Title';
 import { TopBar } from '@components/common/topBar/TopBar';
 import { Theme, css } from '@emotion/react';
+import { useEffect, useState } from 'react';
+
+type ChatRoomType = {
+  id: number;
+} & ChatItemProps;
 
 export const Chat: React.FC = () => {
+  const [chatItems, setChatItems] = useState<ChatRoomType[]>([]);
+
+  useEffect(() => {
+    setTimeout(
+      () =>
+        setChatItems([
+          {
+            id: 1,
+            chatPartner: {
+              id: 1,
+              nickname: 'John',
+              imageUrl: 'https://picsum.photos/200',
+            },
+            lastMessage: 'Hello there!',
+            updatedAt: new Date('2023-09-19T10:30:00'),
+            unreadMessages: 2,
+            thumbnailUrl: 'https://picsum.photos/200',
+          },
+          {
+            id: 2,
+            chatPartner: {
+              id: 2,
+              nickname: 'Alice',
+              imageUrl: 'https://picsum.photos/200',
+            },
+            lastMessage: 'How are you?',
+            updatedAt: new Date('2023-09-18T15:45:00'),
+            unreadMessages: 0,
+            thumbnailUrl: 'https://picsum.photos/200',
+          },
+          {
+            id: 3,
+            chatPartner: {
+              id: 3,
+              nickname: 'Bob',
+              imageUrl: 'https://picsum.photos/200',
+            },
+            lastMessage:
+              '안녕하세요! 한 가지 궁금한 점이 있어서 연락드립니다. 다름이 아니라',
+            updatedAt: new Date('2023-09-17T20:15:00'),
+            unreadMessages: 1,
+            thumbnailUrl: 'https://picsum.photos/200',
+          },
+        ]),
+      3000,
+    );
+  }, []);
+
+  const renderSkeletons = (length: number) => {
+    return Array.from({ length }).map((_, index) => (
+      <SkeletonChatItem key={index} />
+    ));
+  };
+
   return (
     <>
       <TopBar>
         <Title>채팅</Title>
       </TopBar>
-      <div css={(theme) => pageStyle(theme)}></div>
+      <div css={(theme) => pageStyle(theme)}>
+        <ul>
+          {chatItems.length === 0 && renderSkeletons(5)}
+          {chatItems.map((chatItem) => (
+            <ChatItem
+              key={chatItem.id}
+              chatPartner={chatItem.chatPartner}
+              lastMessage={chatItem.lastMessage}
+              updatedAt={chatItem.updatedAt}
+              unreadMessages={chatItem.unreadMessages}
+              thumbnailUrl={chatItem.thumbnailUrl}
+            />
+          ))}
+        </ul>
+      </div>
     </>
   );
 };
@@ -16,7 +90,7 @@ export const Chat: React.FC = () => {
 const pageStyle = (theme: Theme) => {
   return css`
     flex: 1;
-    padding: 73px 16px 0;
+    padding-top: 57px;
     margin-bottom: 64px;
     overflow-x: hidden;
     overflow-y: auto;

--- a/fe/src/pages/Chat.tsx
+++ b/fe/src/pages/Chat.tsx
@@ -15,7 +15,32 @@ export const Chat: React.FC = () => {
 
 const pageStyle = (theme: Theme) => {
   return css`
-    background-color: ${theme.color.neutral.backgroundBold};
     flex: 1;
+    padding: 73px 16px 0;
+    margin-bottom: 64px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    background-color: ${theme.color.neutral.background};
+
+    &::-webkit-scrollbar {
+      width: 10px;
+      background-color: ${theme.color.neutral.background};
+    }
+
+    &::-webkit-scrollbar-button {
+      width: 0;
+      height: 0;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      width: 4px;
+      border-radius: 10px;
+      background-color: ${theme.color.neutral.border};
+      border: 3px solid ${theme.color.neutral.background};
+    }
+
+    &::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
   `;
 };

--- a/fe/src/queries/auth.ts
+++ b/fe/src/queries/auth.ts
@@ -1,6 +1,7 @@
 import { checkNickname, login, logout, refreshToken, signup } from '@api/api';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getRefreshToken, setAccessToken } from '@utils/localStorage';
+import { useEffect } from 'react';
 import { useMutation, useQuery } from 'react-query';
 
 export const useNicknameCheck = (nickname: string) =>
@@ -29,9 +30,12 @@ export const useTokenRefresh = () => {
     },
   });
 
-  if (tokenRefreshQuery.data) {
-    setAccessToken(tokenRefreshQuery.data);
-  }
+  useEffect(() => {
+    if (tokenRefreshQuery.data) {
+      setAccessToken(tokenRefreshQuery.data);
+    }
+  }, [tokenRefreshQuery.data])
+
 };
 
 export const useSignup = () =>


### PR DESCRIPTION
## What is this PR? 👓

- 채팅방 목록 페이지의 레이아웃
- 채팅방 항목 컴포넌트 생성

## Key changes 🔑

![image](https://github.com/masters2023-4th-project-carrot-talk/carrot-talk-fe/assets/60080167/3dfb9b90-3f17-4d5e-b90c-26a4a60f9cc8)


- ChatItem : 채팅방 항목
  - 마지막 메시지가 ...으로 말줄임처리 되어야 합니다. `text-overflow` 적용하니 flex: 1 때문에 너비가 너무 커집니다.
  - figma 스타일 코드를 참고해서 처리했지만, -webkit-box-orient는 deprecated 속성이라 우려스럽긴 합니다. 다만 caniuse에서 호환성 확인을 했을 때 대부분의 메이저 브라우저에서 지원하기 때문에 일단 그대로 유지하겠습니다.
  - [caniuse - -webkit-box-orient 검색 결과](https://caniuse.com/?search=-webkit-box-orient)
  - [MDN - box-orient](https://developer.mozilla.org/en-US/docs/Web/CSS/box-orient)

## To reviewers 👋

- ChatItemProps는 회의 전에 작성된 코드라 API 문서에 맞춰서 수정이 필요합니다.
- useTokenRefresh 훅 안에 if문 useEffect 안에 넣었습니다.